### PR TITLE
fix: fetch records from partition leader

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -92,7 +92,7 @@ impl Client {
         num_partitions: i32,
         replication_factor: i16,
     ) -> Result<()> {
-        let broker = self.brokers.get_cached_broker().await?;
+        let broker = self.brokers.get_arbitrary_cached_broker().await?;
         let response = broker
             .request(CreateTopicsRequest {
                 topics: vec![CreateTopicRequest {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -79,7 +79,7 @@ impl BrokerConnector {
     /// Requests data for all topics if `topics` is `None`
     pub async fn request_metadata(&self, topics: Option<Vec<String>>) -> Result<MetadataResponse> {
         // TODO: Add retry logic
-        let broker = self.get_cached_broker().await?;
+        let broker = self.get_arbitrary_cached_broker().await?;
 
         let response = broker
             .request(MetadataRequest {
@@ -101,7 +101,7 @@ impl BrokerConnector {
     ///
     /// The next call to `[BrokerPool::get_cached_broker]` will get a new connection
     #[allow(dead_code)]
-    pub async fn invalidate_cached_broker(&self) {
+    pub async fn invalid_cached_arbitrary_broker(&self) {
         self.current_broker.lock().await.take();
     }
 
@@ -128,7 +128,7 @@ impl BrokerConnector {
     }
 
     /// Gets a cached [`BrokerConnection`] to any broker
-    pub async fn get_cached_broker(&self) -> Result<BrokerConnection> {
+    pub async fn get_arbitrary_cached_broker(&self) -> Result<BrokerConnection> {
         let mut current_broker = self.current_broker.lock().await;
         if let Some(broker) = &*current_broker {
             return Ok(Arc::clone(broker));

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -24,7 +24,7 @@ async fn test_partition_leader() {
 
     client.create_topic(&topic_name, 2, 1).await.unwrap();
     let client = client.partition_client(&topic_name, 0).await.unwrap();
-    client.get_cached_broker().await.unwrap();
+    client.get_cached_leader().await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
Split out from #35 and causing #37 tests to correctly fail. I renamed the functions to hopefully reduce the chance of this type of bug in future