### PR TITLE
fix: Request a new broker after invalidating the cached broker

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -140,7 +140,7 @@ impl BrokerConnector {
 
     /// Invalidates the current cached broker
     ///
-    /// The next call to `[BrokerPool::get_cached_broker]` will get a new connection
+    /// The next call to `[BrokerConnector::get_arbitrary_cached_broker]` will get a new connection
     #[allow(dead_code)]
     pub async fn invalidate_cached_arbitrary_broker(&self) {
         self.current_broker.lock().await.take();


### PR DESCRIPTION
While trying to manually test leader failover, I saw that calling `request_metadata` after a broker was killed would back off and continue failing.

I noticed the comment on `invalidate_cached_arbitrary_broker` that said the next call to `BrokerPool::get_cached_broker` would get a new connection, but 1. that doesn't appear to exist anymore and 2. nowhere in the retry loop was the broker changing.

It looks like [this commit removed the refreshing of the broker in the loop](https://github.com/influxdata/rskafka/pull/51/commits/c5c919f82c8dbcb5d07b0f94090175d0aa39ad2b#diff-68923d8302dccbcf4197d9a4d936226739cb7348ad30f173f7de2f301c23b0afL103) in favor of the broker passed in, which means calling `invalidate_cached_arbitrary_broker` has no effect and calling a broker that's returning an error will continue to call that same broker and error forever.

I don't have an automated test yet for the correct behavior, I'm still thinking about how to inject error states with mocks and such, but I figured this would be good to have in the meantime.