### PR TITLE
feat: more flexible producer pipeline

### DIFF
--- a/src/client/producer/aggregator.rs
+++ b/src/client/producer/aggregator.rs
@@ -59,7 +59,7 @@ pub trait Aggregator: Send {
 }
 
 /// De-aggregate status for successful `produce` operations.
-pub trait StatusDeaggregator: Send + std::fmt::Debug {
+pub trait StatusDeaggregator: Send + Sync + std::fmt::Debug {
     /// The de-aggregated output status.
     type Status;
 


### PR DESCRIPTION
- separate aggregation and transformation (i.e. user type => Record)
- allow status (currently only the offset, potentially more information
  in the future) to be transformed back to the user

The use case being that in IOx we can now use our custom data type
(DmlOperation) to aggregate data and even get the offsets and tracing
spans back that we want for unit testing.

For RSKafka the default record-based aggregator now returns proper
offsets as well, so you don't loose anything in comparison to direct
`PartitionClient::produce` calls.
