### PR TITLE
feat: SOCK5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,6 +285,51 @@ jobs:
           command: cargo test --benches --no-run
       - cache_save
 
+  # Builds RSKafka with minimal features.
+  build-no-default-features:
+    docker:
+      - image: quay.io/influxdb/rust:ci
+    resource_class: xlarge  # use of a smaller executor tends crashes on link
+    environment:
+      # Disable incremental compilation to avoid overhead. We are not preserving these files anyway.
+      CARGO_INCREMENTAL: "0"
+      # Disable full debug symbol generation to speed up CI build
+      # "1" means line tables only, which is useful for panic tracebacks.
+      RUSTFLAGS: "-C debuginfo=1"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+    steps:
+      - checkout
+      - rust_components
+      - cache_restore
+      - run:
+          name: Cargo build
+          command: cargo build --no-default-features
+      - cache_save
+
+  # Builds RSKafka w/ all features.
+  build-all-features:
+    docker:
+      - image: quay.io/influxdb/rust:ci
+    resource_class: xlarge  # use of a smaller executor tends crashes on link
+    environment:
+      # Disable incremental compilation to avoid overhead. We are not preserving these files anyway.
+      CARGO_INCREMENTAL: "0"
+      # Disable full debug symbol generation to speed up CI build
+      # "1" means line tables only, which is useful for panic tracebacks.
+      RUSTFLAGS: "-C debuginfo=1"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+    steps:
+      - checkout
+      - rust_components
+      - cache_restore
+      - run:
+          name: Cargo build
+          command: cargo build --all-features
+      - cache_save
+
+
   # Builds fuzzing.
   build-fuzz:
     docker:
@@ -325,5 +370,7 @@ workflows:
       - test-redpanda
       - test-kafka
       - build-default-features
+      - build-no-default-features
+      - build-all-features
       - build-fuzz
       - doc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - cache_restore
       - run:
           name: Cargo test
-          command: cargo test --workspace
+          command: cargo test --all-features --workspace
       - cache_save
       - store_artifacts:
           path: proptest-regressions
@@ -255,7 +255,7 @@ jobs:
       - cache_restore
       - run:
           name: Cargo test
-          command: cargo test --workspace
+          command: cargo test --all-features --workspace
       - cache_save
       - store_artifacts:
           path: proptest-regressions
@@ -280,9 +280,6 @@ jobs:
       - run:
           name: Cargo build
           command: cargo build
-      - run:
-          name: Build benches
-          command: cargo test --benches --no-run
       - cache_save
 
   # Builds RSKafka with minimal features.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ time = "0.3"
 tokio = { version = "1.14", default-features = false, features = ["io-util", "net", "rt", "sync", "time"] }
 tokio-rustls = { version = "0.23", optional = true }
 tracing = "0.1"
+async-socks5 = { version = "0.5", optional = true }
 varint-rs = "2.2"
 
 [dev-dependencies]
@@ -38,6 +39,7 @@ uuid = { version = "0.8", features = ["v4"] }
 default = ["transport-tls"]
 fuzzing = []
 transport-tls = ["rustls", "tokio-rustls"]
+transport-socks5 = ["async-socks5"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ futures = "0.3"
 parking_lot = "0.11"
 pin-project-lite = "0.2"
 rand = "0.8"
-rustls = "0.20"
+rustls = { version = "0.20", optional = true }
 thiserror = "1.0"
 time = "0.3"
 tokio = { version = "1.14", default-features = false, features = ["io-util", "net", "rt", "sync", "time"] }
-tokio-rustls = "0.23"
+tokio-rustls = { version = "0.23", optional = true }
 tracing = "0.1"
 varint-rs = "2.2"
 
@@ -35,7 +35,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "0.8", features = ["v4"] }
 
 [features]
+default = ["transport-tls"]
 fuzzing = []
+transport-tls = ["rustls", "tokio-rustls"]
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ For more advanced production and consumption, see [`crate::client::producer`] an
 - **`fuzzing`:** Exposes some internal data structures so that they can be used by our fuzzers. This is NOT a stable
   feature / API!
 - **`transport-tls` (default):** Allows TLS transport via [`rustls`].
+- **`transport-socks5`:** Allow transport via SOCKS5 proxy.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It will be a good fit for workloads that:
 ```rust,no_run
 # async fn test() {
 use rskafka::{
-    client::Client,
+    client::ClientBuilder,
     record::Record,
 };
 use time::OffsetDateTime;
@@ -33,7 +33,7 @@ use std::collections::BTreeMap;
 
 // setup client
 let connection = "localhost:9093".to_owned();
-let client = Client::new_plain(vec![connection]).await.unwrap();
+let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
 
 // create a topic
 let topic = "my_topic";
@@ -77,6 +77,13 @@ let (records, high_watermark) = partition_client
 ```
 
 For more advanced production and consumption, see [`crate::client::producer`] and [`crate::client::consumer`].
+
+
+## Features
+
+- **`fuzzing`:** Exposes some internal data structures so that they can be used by our fuzzers. This is NOT a stable
+  feature / API!
+- **`transport-tls` (default):** Allows TLS transport via [`rustls`].
 
 ## Testing
 
@@ -201,3 +208,4 @@ e.g. by batching writes to multiple partitions in a single ProduceRequest
 [IOx]: https://github.com/influxdata/influxdb_iox/
 [LLDB]: https://lldb.llvm.org/
 [Redpanda]: https://vectorized.io/redpanda
+[rustls]: https://github.com/rustls/rustls

--- a/src/client/consumer.rs
+++ b/src/client/consumer.rs
@@ -5,14 +5,14 @@
 //! # async fn test() {
 //! use futures::StreamExt;
 //! use rskafka::client::{
-//!     Client,
+//!     ClientBuilder,
 //!     consumer::StreamConsumerBuilder,
 //! };
 //! use std::sync::Arc;
 //!
 //! // get partition client
 //! let connection = "localhost:9093".to_owned();
-//! let client = Client::new_plain(vec![connection]).await.unwrap();
+//! let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
 //! let partition_client = Arc::new(
 //!     client.partition_client("my_topic", 0).await.unwrap()
 //! );

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use crate::{
-    client::partition::PartitionClient, connection::BrokerConnector, protocol::primitives::Boolean,
+    client::partition::PartitionClient,
+    connection::{BrokerConnector, TlsConfig},
+    protocol::primitives::Boolean,
     topic::Topic,
 };
 
@@ -32,39 +34,53 @@ pub enum ProduceError {
     NoResult { index: usize },
 }
 
+/// Builder for [`Client`].
+pub struct ClientBuilder {
+    bootstrap_brokers: Vec<String>,
+    tls_config: TlsConfig,
+}
+
+impl ClientBuilder {
+    /// Create a new [`ClientBuilder`] with the list of bootstrap brokers
+    pub fn new(bootstrap_brokers: Vec<String>) -> Self {
+        Self {
+            bootstrap_brokers,
+            tls_config: TlsConfig::default(),
+        }
+    }
+
+    /// Setup TLS.
+    #[cfg(feature = "transport-tls")]
+    pub fn tls_config(mut self, tls_config: Arc<rustls::ClientConfig>) -> Self {
+        self.tls_config = Some(tls_config);
+        self
+    }
+
+    /// Build [`Client`].
+    pub async fn build(self) -> Result<Client> {
+        let brokers = Arc::new(BrokerConnector::new(
+            self.bootstrap_brokers,
+            self.tls_config,
+            1024 * 1024 * 1024,
+        ));
+        brokers.refresh_metadata().await?;
+
+        Ok(Client { brokers })
+    }
+}
+
+impl std::fmt::Debug for ClientBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientBuilder").finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug)]
 pub struct Client {
     brokers: Arc<BrokerConnector>,
 }
 
 impl Client {
-    /// Create a new [`Client`] with the list of bootstrap brokers
-    pub async fn new_plain(boostrap_brokers: Vec<String>) -> Result<Self> {
-        Self::new(boostrap_brokers, None).await
-    }
-
-    /// Create a new [`Client`] using TLS
-    pub async fn new_with_tls(
-        boostrap_brokers: Vec<String>,
-        tls_config: Arc<rustls::ClientConfig>,
-    ) -> Result<Self> {
-        Self::new(boostrap_brokers, Some(tls_config)).await
-    }
-
-    async fn new(
-        boostrap_brokers: Vec<String>,
-        tls_config: Option<Arc<rustls::ClientConfig>>,
-    ) -> Result<Self> {
-        let brokers = Arc::new(BrokerConnector::new(
-            boostrap_brokers,
-            tls_config,
-            1024 * 1024 * 1024,
-        ));
-        brokers.refresh_metadata().await?;
-
-        Ok(Self { brokers })
-    }
-
     /// Returns a client for performing certain cluster-wide operations.
     pub async fn controller_client(&self) -> Result<ControllerClient> {
         Ok(ControllerClient::new(Arc::clone(&self.brokers)))

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -38,6 +38,7 @@ pub enum ProduceError {
 pub struct ClientBuilder {
     bootstrap_brokers: Vec<String>,
     tls_config: TlsConfig,
+    socks5_proxy: Option<String>,
 }
 
 impl ClientBuilder {
@@ -46,6 +47,7 @@ impl ClientBuilder {
         Self {
             bootstrap_brokers,
             tls_config: TlsConfig::default(),
+            socks5_proxy: None,
         }
     }
 
@@ -56,11 +58,19 @@ impl ClientBuilder {
         self
     }
 
+    /// Use SOCKS5 proxy.
+    #[cfg(feature = "transport-socks5")]
+    pub fn socks5_proxy(mut self, proxy: String) -> Self {
+        self.socks5_proxy = Some(proxy);
+        self
+    }
+
     /// Build [`Client`].
     pub async fn build(self) -> Result<Client> {
         let brokers = Arc::new(BrokerConnector::new(
             self.bootstrap_brokers,
             self.tls_config,
+            self.socks5_proxy,
             1024 * 1024 * 1024,
         ));
         brokers.refresh_metadata().await?;

--- a/src/client/producer.rs
+++ b/src/client/producer.rs
@@ -41,7 +41,7 @@
 //! # async fn test() {
 //! use rskafka::{
 //!     client::{
-//!         Client,
+//!         ClientBuilder,
 //!         producer::{
 //!             aggregator::RecordAggregator,
 //!             BatchProducerBuilder,
@@ -58,7 +58,7 @@
 //!
 //! // get partition client
 //! let connection = "localhost:9093".to_owned();
-//! let client = Client::new_plain(vec![connection]).await.unwrap();
+//! let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
 //! let partition_client = Arc::new(
 //!     client.partition_client("my_topic", 0).await.unwrap()
 //! );
@@ -90,7 +90,7 @@
 //! # async fn test() {
 //! use rskafka::{
 //!     client::{
-//!         Client,
+//!         ClientBuilder,
 //!         producer::{
 //!             aggregator::{
 //!                 Aggregator,
@@ -175,7 +175,7 @@
 //!
 //! // get partition client
 //! let connection = "localhost:9093".to_owned();
-//! let client = Client::new_plain(vec![connection]).await.unwrap();
+//! let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
 //! let partition_client = Arc::new(
 //!     client.partition_client("my_topic", 0).await.unwrap()
 //! );

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -13,6 +13,8 @@ use crate::messenger::{Messenger, RequestError};
 use crate::protocol::messages::{MetadataRequest, MetadataRequestTopic, MetadataResponse};
 use crate::protocol::primitives::String_;
 
+pub use self::transport::TlsConfig;
+
 mod topology;
 mod transport;
 
@@ -59,7 +61,7 @@ pub struct BrokerConnector {
     backoff_config: BackoffConfig,
 
     /// TLS configuration if any
-    tls_config: Option<Arc<rustls::ClientConfig>>,
+    tls_config: TlsConfig,
 
     /// Maximum message size for framing protocol.
     max_message_size: usize,
@@ -68,7 +70,7 @@ pub struct BrokerConnector {
 impl BrokerConnector {
     pub fn new(
         bootstrap_brokers: Vec<String>,
-        tls_config: Option<Arc<rustls::ClientConfig>>,
+        tls_config: TlsConfig,
         max_message_size: usize,
     ) -> Self {
         Self {
@@ -148,16 +150,12 @@ impl BrokerConnector {
 
 impl std::fmt::Debug for BrokerConnector {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let tls_config: &'static str = match self.tls_config {
-            Some(_) => "Some",
-            None => "None",
-        };
         f.debug_struct("BrokerConnector")
             .field("bootstrap_brokers", &self.bootstrap_brokers)
             .field("topology", &self.topology)
             .field("cached_arbitrary_broker", &self.cached_arbitrary_broker)
             .field("backoff_config", &self.backoff_config)
-            .field("tls_config", &tls_config)
+            .field("tls_config", &"...")
             .field("max_message_size", &self.max_message_size)
             .finish()
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -63,6 +63,9 @@ pub struct BrokerConnector {
     /// TLS configuration if any
     tls_config: TlsConfig,
 
+    /// SOCKS5 proxy.
+    socks5_proxy: Option<String>,
+
     /// Maximum message size for framing protocol.
     max_message_size: usize,
 }
@@ -71,6 +74,7 @@ impl BrokerConnector {
     pub fn new(
         bootstrap_brokers: Vec<String>,
         tls_config: TlsConfig,
+        socks5_proxy: Option<String>,
         max_message_size: usize,
     ) -> Self {
         Self {
@@ -79,6 +83,7 @@ impl BrokerConnector {
             cached_arbitrary_broker: Mutex::new(None),
             backoff_config: Default::default(),
             tls_config,
+            socks5_proxy,
             max_message_size,
         }
     }
@@ -132,7 +137,7 @@ impl BrokerConnector {
 
     async fn connect_impl(&self, broker_id: Option<i32>, url: &str) -> Result<BrokerConnection> {
         info!(broker = broker_id, url, "Establishing new connection",);
-        let transport = Transport::connect(url, self.tls_config.clone())
+        let transport = Transport::connect(url, self.tls_config.clone(), self.socks5_proxy.clone())
             .await
             .map_err(|error| Error::Transport {
                 broker: url.to_string(),

--- a/src/connection/transport.rs
+++ b/src/connection/transport.rs
@@ -1,24 +1,34 @@
 use pin_project_lite::pin_project;
 use std::pin::Pin;
+#[cfg(feature = "transport-tls")]
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
-use tokio_rustls::client::TlsStream;
-use tokio_rustls::TlsConnector;
+
+#[cfg(feature = "transport-tls")]
+use tokio_rustls::{client::TlsStream, TlsConnector};
+
+#[cfg(feature = "transport-tls")]
+pub type TlsConfig = Option<Arc<rustls::ClientConfig>>;
+
+#[cfg(not(feature = "transport-tls"))]
+pub type TlsConfig = ();
 
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("IO Error: {0}")]
     IO(#[from] std::io::Error),
 
+    #[cfg(feature = "transport-tls")]
     #[error("Invalid Hostname: {0}")]
     BadHostname(#[from] rustls::client::InvalidDnsNameError),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+#[cfg(feature = "transport-tls")]
 pin_project! {
     #[project = TransportProj]
     #[derive(Debug)]
@@ -27,9 +37,22 @@ pin_project! {
             #[pin]
             inner: TcpStream,
         },
+
         Tls{
             #[pin]
             inner: Box<TlsStream<TcpStream>>,
+        },
+    }
+}
+
+#[cfg(not(feature = "transport-tls"))]
+pin_project! {
+    #[project = TransportProj]
+    #[derive(Debug)]
+    pub enum Transport {
+        Plain{
+            #[pin]
+            inner: TcpStream,
         },
     }
 }
@@ -42,6 +65,8 @@ impl AsyncRead for Transport {
     ) -> Poll<std::io::Result<()>> {
         match self.project() {
             TransportProj::Plain { inner } => inner.poll_read(cx, buf),
+
+            #[cfg(feature = "transport-tls")]
             TransportProj::Tls { inner } => inner.poll_read(cx, buf),
         }
     }
@@ -55,6 +80,8 @@ impl AsyncWrite for Transport {
     ) -> Poll<std::io::Result<usize>> {
         match self.project() {
             TransportProj::Plain { inner } => inner.poll_write(cx, buf),
+
+            #[cfg(feature = "transport-tls")]
             TransportProj::Tls { inner } => inner.poll_write(cx, buf),
         }
     }
@@ -62,6 +89,8 @@ impl AsyncWrite for Transport {
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
         match self.project() {
             TransportProj::Plain { inner } => inner.poll_flush(cx),
+
+            #[cfg(feature = "transport-tls")]
             TransportProj::Tls { inner } => inner.poll_flush(cx),
         }
     }
@@ -69,17 +98,21 @@ impl AsyncWrite for Transport {
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
         match self.project() {
             TransportProj::Plain { inner } => inner.poll_shutdown(cx),
+
+            #[cfg(feature = "transport-tls")]
             TransportProj::Tls { inner } => inner.poll_shutdown(cx),
         }
     }
 }
 
 impl Transport {
-    pub async fn connect(
-        broker: &str,
-        tls_config: Option<Arc<rustls::ClientConfig>>,
-    ) -> Result<Self> {
+    pub async fn connect(broker: &str, tls_config: TlsConfig) -> Result<Self> {
         let tcp_stream = TcpStream::connect(&broker).await?;
+        Self::wrap_tls(tcp_stream, broker, tls_config).await
+    }
+
+    #[cfg(feature = "transport-tls")]
+    async fn wrap_tls(tcp_stream: TcpStream, broker: &str, tls_config: TlsConfig) -> Result<Self> {
         match tls_config {
             Some(config) => {
                 // Strip port if any
@@ -94,5 +127,14 @@ impl Transport {
             }
             None => Ok(Self::Plain { inner: tcp_stream }),
         }
+    }
+
+    #[cfg(not(feature = "transport-tls"))]
+    async fn wrap_tls(
+        tcp_stream: TcpStream,
+        _broker: &str,
+        _tls_config: TlsConfig,
+    ) -> Result<Self> {
+        Ok(Self::Plain { inner: tcp_stream })
     }
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -2,7 +2,7 @@ use rskafka::{
     client::{
         error::{Error as ClientError, ProtocolError},
         partition::PartitionClient,
-        Client,
+        ClientBuilder,
     },
     record::{Record, RecordAndOffset},
 };
@@ -20,7 +20,7 @@ async fn test_plain() {
     maybe_start_logging();
 
     let connection = maybe_skip_kafka_integration!();
-    Client::new_plain(vec![connection]).await.unwrap();
+    ClientBuilder::new(vec![connection]).build().await.unwrap();
 }
 
 #[tokio::test]
@@ -28,7 +28,7 @@ async fn test_partition_leader() {
     maybe_start_logging();
 
     let connection = maybe_skip_kafka_integration!();
-    let client = Client::new_plain(vec![connection]).await.unwrap();
+    let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
     let controller_client = client.controller_client().await.unwrap();
     let topic_name = random_topic_name();
 
@@ -57,7 +57,7 @@ async fn test_topic_crud() {
     maybe_start_logging();
 
     let connection = maybe_skip_kafka_integration!();
-    let client = Client::new_plain(vec![connection]).await.unwrap();
+    let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
     let controller_client = client.controller_client().await.unwrap();
     let topics = client.list_topics().await.unwrap();
 
@@ -140,7 +140,9 @@ async fn test_tls() {
         .unwrap();
 
     let connection = maybe_skip_kafka_integration!();
-    Client::new_with_tls(vec![connection], Arc::new(config))
+    ClientBuilder::new(vec![connection])
+        .tls_config(Arc::new(config))
+        .build()
         .await
         .unwrap();
 }
@@ -153,7 +155,7 @@ async fn test_produce_empty() {
     let topic_name = random_topic_name();
     let n_partitions = 2;
 
-    let client = Client::new_plain(vec![connection]).await.unwrap();
+    let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
     let controller_client = client.controller_client().await.unwrap();
     controller_client
         .create_topic(&topic_name, n_partitions, 1)
@@ -192,7 +194,10 @@ async fn test_get_high_watermark() {
     let topic_name = random_topic_name();
     let n_partitions = 1;
 
-    let client = Client::new_plain(vec![connection.clone()]).await.unwrap();
+    let client = ClientBuilder::new(vec![connection.clone()])
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().await.unwrap();
     controller_client
         .create_topic(&topic_name, n_partitions, 1)
@@ -244,7 +249,10 @@ where
     let topic_name = random_topic_name();
     let n_partitions = 2;
 
-    let client = Client::new_plain(vec![connection.clone()]).await.unwrap();
+    let client = ClientBuilder::new(vec![connection.clone()])
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().await.unwrap();
     controller_client
         .create_topic(&topic_name, n_partitions, 1)

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -147,6 +147,25 @@ async fn test_tls() {
         .unwrap();
 }
 
+// Disabled as currently no SOCKS5 integration tests
+#[cfg(feature = "transport-socks5")]
+#[ignore]
+#[tokio::test]
+async fn test_socks5() {
+    maybe_start_logging();
+
+    let client = ClientBuilder::new(vec!["my-cluster-kafka-bootstrap:9092".to_owned()])
+        .socks5_proxy("localhost:1080".to_owned())
+        .build()
+        .await
+        .unwrap();
+    let partition_client = client.partition_client("myorg_mybucket", 0).await.unwrap();
+    partition_client
+        .fetch_records(0, 1..10_000_001, 1_000)
+        .await
+        .unwrap();
+}
+
 #[tokio::test]
 async fn test_produce_empty() {
     maybe_start_logging();

--- a/tests/consumer.rs
+++ b/tests/consumer.rs
@@ -6,7 +6,7 @@ use tokio::time::timeout;
 
 use rskafka::client::{
     consumer::{StreamConsumer, StreamConsumerBuilder},
-    Client,
+    ClientBuilder,
 };
 use test_helpers::{maybe_start_logging, random_topic_name, record};
 
@@ -17,7 +17,7 @@ async fn test_stream_consumer() {
     maybe_start_logging();
 
     let connection = maybe_skip_kafka_integration!();
-    let client = Client::new_plain(vec![connection]).await.unwrap();
+    let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
     let controller_client = client.controller_client().await.unwrap();
 
     let topic = random_topic_name();

--- a/tests/producer.rs
+++ b/tests/producer.rs
@@ -1,7 +1,7 @@
 use futures::{future::FusedFuture, pin_mut, FutureExt};
 use rskafka::client::{
     producer::{aggregator::RecordAggregator, BatchProducerBuilder},
-    Client,
+    ClientBuilder,
 };
 use std::time::Duration;
 
@@ -14,7 +14,7 @@ async fn test_batch_producer() {
     maybe_start_logging();
 
     let connection = maybe_skip_kafka_integration!();
-    let client = Client::new_plain(vec![connection]).await.unwrap();
+    let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
     let controller_client = client.controller_client().await.unwrap();
 
     let topic = random_topic_name();


### PR DESCRIPTION
This is really handy if you wanna debug interactions with cluster running in K8s. Now you just need the [kubectl SOCKS5 plugin](https://github.com/yokawasa/kubectl-plugin-socks5-proxy) and it "just works".

Since adding yet another connect method didn't feel right, I've moved the client creation over to a builder pattern and to proof that it is nice and modular, I've made TLS optional (which some OSS users might welcome).