### PR TITLE
refactor: Add a little testability, abstract a bit over broker kinds

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -44,7 +44,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 trait ConnectionHandler {
     type R: RequestHandler + Send + Sync;
 
-    async fn connection(
+    async fn connect(
         &self,
         tls_config: TlsConfig,
         socks5_proxy: Option<String>,
@@ -81,7 +81,7 @@ impl BrokerRepresentation {
 impl ConnectionHandler for BrokerRepresentation {
     type R = MessengerTransport;
 
-    async fn connection(
+    async fn connect(
         &self,
         tls_config: TlsConfig,
         socks5_proxy: Option<String>,
@@ -199,7 +199,7 @@ impl BrokerConnector {
         match self.topology.get_broker(broker_id).await {
             Some(broker) => {
                 let connection = BrokerRepresentation::Topology(broker)
-                    .connection(
+                    .connect(
                         self.tls_config.clone(),
                         self.socks5_proxy.clone(),
                         self.max_message_size,
@@ -317,7 +317,7 @@ where
         .retry_with_backoff("broker_connect", || async {
             for broker in &brokers {
                 let conn = broker
-                    .connection(tls_config.clone(), socks5_proxy.clone(), max_message_size)
+                    .connect(tls_config.clone(), socks5_proxy.clone(), max_message_size)
                     .await;
 
                 let connection = match conn {
@@ -602,7 +602,7 @@ mod tests {
     impl ConnectionHandler for FakeBrokerConn {
         type R = FakeConn;
 
-        async fn connection(
+        async fn connect(
             &self,
             _tls_config: Option<Arc<rustls::ClientConfig>>,
             _socks5_proxy: Option<String>,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -581,7 +581,7 @@ mod tests {
         RequestError::IO(std::io::Error::from(std::io::ErrorKind::UnexpectedEof))
     }
 
-    struct FakeBrokerConn {
+    struct FakeBrokerRepresentation {
         conn: Box<dyn Fn() -> Result<Arc<FakeConn>> + Send + Sync>,
     }
 
@@ -599,7 +599,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl ConnectionHandler for FakeBrokerConn {
+    impl ConnectionHandler for FakeBrokerRepresentation {
         type R = FakeConn;
 
         async fn connect(
@@ -616,11 +616,11 @@ mod tests {
     async fn connect_picks_successful_broker() {
         let brokers = vec![
             // One broker where `connection` always succceeds
-            FakeBrokerConn {
+            FakeBrokerRepresentation {
                 conn: Box::new(|| Ok(Arc::new(FakeConn))),
             },
             // One broker where `connection` always fails (recoverable/fatal doesn't matter)
-            FakeBrokerConn {
+            FakeBrokerRepresentation {
                 conn: Box::new(|| Err(Error::Metadata(arbitrary_recoverable_error()))),
             },
         ];

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -42,7 +42,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 /// How to connect to a `Transport`
 #[async_trait]
 trait Connect {
-    type R: Request + Send + Sync;
+    type R: RequestHandler + Send + Sync;
 
     async fn connection(
         &self,
@@ -244,7 +244,7 @@ impl std::fmt::Debug for BrokerConnector {
 }
 
 #[async_trait]
-trait Request {
+trait RequestHandler {
     async fn metadata_request(
         &self,
         request_params: &MetadataRequest,
@@ -252,7 +252,7 @@ trait Request {
 }
 
 #[async_trait]
-impl Request for MessengerTransport {
+impl RequestHandler for MessengerTransport {
     async fn metadata_request(
         &self,
         request_params: &MetadataRequest,
@@ -263,7 +263,7 @@ impl Request for MessengerTransport {
 
 #[async_trait]
 trait ArbitraryBrokerCache: Send + Sync {
-    type R: Request + Send + Sync;
+    type R: RequestHandler + Send + Sync;
 
     async fn get(&self) -> Result<Arc<Self::R>>;
 
@@ -398,7 +398,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl Request for FakeBroker {
+    impl RequestHandler for FakeBroker {
         async fn metadata_request(
             &self,
             _request_params: &MetadataRequest,
@@ -589,7 +589,7 @@ mod tests {
     struct FakeConn;
 
     #[async_trait]
-    impl Request for FakeConn {
+    impl RequestHandler for FakeConn {
         async fn metadata_request(
             &self,
             _request_params: &MetadataRequest,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -129,14 +129,14 @@ impl BrokerConnector {
 
     /// Returns a new connection to the broker with the provided id
     pub async fn connect(&self, broker_id: i32) -> Result<Option<BrokerConnection>> {
-        match self.topology.get_broker_url(broker_id).await {
-            Some(url) => {
+        match self.topology.get_broker(broker_id).await {
+            Some(broker) => {
                 let connection = new_broker_connection(
                     self.tls_config.clone(),
                     self.socks5_proxy.clone(),
                     self.max_message_size,
                     Some(broker_id),
-                    &url,
+                    &broker.to_string(),
                 )
                 .await?;
                 Ok(Some(connection))
@@ -219,7 +219,11 @@ impl ArbitraryBrokerCache for &BrokerConnector {
         let mut brokers = if self.topology.is_empty() {
             self.bootstrap_brokers.clone()
         } else {
-            self.topology.get_broker_urls()
+            self.topology
+                .get_brokers()
+                .iter()
+                .map(ToString::to_string)
+                .collect()
         };
 
         // Randomise search order to encourage different clients to choose different brokers

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -52,7 +52,7 @@ trait Connect {
     ) -> Result<Arc<Self::R>>;
 }
 
-/// Info needed to connect to a broker, with optional broker ID for debugging
+/// Info needed to connect to a broker, with [optional broker ID](Self::id) for debugging
 enum BrokerRepresentation {
     /// URL specified as a bootstrap broker
     Bootstrap(String),

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -41,7 +41,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// How to connect to a `Transport`
 #[async_trait]
-trait Connect {
+trait ConnectionHandler {
     type R: RequestHandler + Send + Sync;
 
     async fn connection(
@@ -78,7 +78,7 @@ impl BrokerRepresentation {
 }
 
 #[async_trait]
-impl Connect for BrokerRepresentation {
+impl ConnectionHandler for BrokerRepresentation {
     type R = MessengerTransport;
 
     async fn connection(
@@ -307,7 +307,7 @@ async fn connect_to_a_broker_with_retry<B>(
     max_message_size: usize,
 ) -> Arc<B::R>
 where
-    B: Connect + Send + Sync,
+    B: ConnectionHandler + Send + Sync,
 {
     // Randomise search order to encourage different clients to choose different brokers
     brokers.shuffle(&mut thread_rng());
@@ -599,7 +599,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl Connect for FakeBrokerConn {
+    impl ConnectionHandler for FakeBrokerConn {
         type R = FakeConn;
 
         async fn connection(

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -39,6 +39,17 @@ pub enum Error {
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// How to connect to a `Transport`
+#[async_trait]
+trait Connect {
+    async fn connection(
+        &self,
+        tls_config: TlsConfig,
+        socks5_proxy: Option<String>,
+        max_message_size: usize,
+    ) -> Result<BrokerConnection>;
+}
+
 /// Info needed to connect to a broker, with optional broker ID for debugging
 enum BrokerRepresentation {
     /// URL specified as a bootstrap broker
@@ -62,7 +73,10 @@ impl BrokerRepresentation {
             BrokerRepresentation::Topology(broker) => broker.to_string(),
         }
     }
+}
 
+#[async_trait]
+impl Connect for BrokerRepresentation {
     async fn connection(
         &self,
         tls_config: TlsConfig,

--- a/src/connection/topology.rs
+++ b/src/connection/topology.rs
@@ -12,7 +12,9 @@ pub struct BrokerTopology {
 }
 
 #[derive(Debug, Clone)]
-struct Broker {
+pub struct Broker {
+    /// broker ID from the topology metadata
+    pub id: i32,
     host: String,
     port: i32,
 }
@@ -26,6 +28,7 @@ impl Display for Broker {
 impl<'a> From<&'a MetadataResponseBroker> for Broker {
     fn from(b: &'a MetadataResponseBroker) -> Self {
         Self {
+            id: b.node_id.0,
             host: b.host.0.clone(),
             port: b.port.0,
         }
@@ -37,21 +40,14 @@ impl BrokerTopology {
         self.topology.read().is_empty()
     }
 
-    /// Returns the broker URL for the provided broker
-    pub async fn get_broker_url(&self, broker_id: i32) -> Option<String> {
-        self.topology
-            .read()
-            .get(&broker_id)
-            .map(ToString::to_string)
+    /// Returns the broker for the provided broker ID
+    pub async fn get_broker(&self, broker_id: i32) -> Option<Broker> {
+        self.topology.read().get(&broker_id).cloned()
     }
 
-    /// Returns a list of all broker URLs
-    pub fn get_broker_urls(&self) -> Vec<String> {
-        self.topology
-            .read()
-            .values()
-            .map(ToString::to_string)
-            .collect()
+    /// Returns a list of all brokers
+    pub fn get_brokers(&self) -> Vec<Broker> {
+        self.topology.read().values().cloned().collect()
     }
 
     /// Updates with the provided broker metadata


### PR DESCRIPTION
Connects to #49, in that it adds a tiny bit of testing around getting a new arbitrary broker connection to cache.

This also adds a bit of type info around different sources of broker connection, and fixes a subtle bug where broker id was being logged as `None` even though we had a broker ID from the topology.

Again recommended to review commit-by-commit.

I feel less confident about the value of these extractions and the new test. If the new test fails, it's likely to be a flaky failure too because of the randomness.

Looking at other code like the controller and partition leader caching, I think perhaps the broker caching trait could be reused, and then perhaps the `maybe_retry` functions could be shared more and tested more? Not sure yet though.