### PR TITLE
feat: support gzip compression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,15 @@ commands:
             - /usr/local/cargo/registry
           key: cargo-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.toml" }}
 
+  install_zlib_dev:
+    description: Install zlib-dev
+    steps:
+      - run:
+          name: Install zlib-dev
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y zlib1g-dev
+
 jobs:
   fmt:
     docker:
@@ -188,6 +197,7 @@ jobs:
       - checkout
       - rust_components
       - cache_restore
+      - install_zlib_dev
       - run:
           name: Cargo test
           command: cargo test --all-features --all-targets
@@ -253,6 +263,7 @@ jobs:
       - checkout
       - rust_components
       - cache_restore
+      - install_zlib_dev
       - run:
           name: Cargo test
           command: cargo test --all-features --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ proptest-derive = "0.3"
 rustls-pemfile = "0.2"
 rdkafka = "0.28"
 tokio = { version = "1.14", features = ["macros", "rt-multi-thread"] }
+tracing-log = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "0.8", features = ["v4"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ async-socks5 = { version = "0.5", optional = true }
 async-trait = "0.1"
 bytes = "1.1"
 crc32c = "0.6"
+flate2 = { version = "1", optional = true }
 futures = "0.3"
 integer-encoding = "3"
 parking_lot = "0.12"
@@ -50,9 +51,11 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [features]
 default = ["transport-tls"]
+
+compression-gzip = ["flate2"]
 fuzzing = []
-transport-tls = ["rustls", "tokio-rustls"]
 transport-socks5 = ["async-socks5"]
+transport-tls = ["rustls", "tokio-rustls"]
 
 [[bench]]
 name = "write_throughput"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ It will be a good fit for workloads that:
 ```rust,no_run
 # async fn test() {
 use rskafka::{
-    client::ClientBuilder,
+    client::{
+        ClientBuilder,
+        partition::Compression,
+    },
     record::Record,
 };
 use time::OffsetDateTime;
@@ -68,7 +71,7 @@ let record = Record {
     ]),
     timestamp: OffsetDateTime::now_utc(),
 };
-partition_client.produce(vec![record]).await.unwrap();
+partition_client.produce(vec![record], Compression::default()).await.unwrap();
 
 // consume data
 let (records, high_watermark) = partition_client
@@ -87,10 +90,11 @@ For more advanced production and consumption, see [`crate::client::producer`] an
 
 ## Features
 
+- **`compression-gzip`:** Support compression and decompression of messages using [gzip].
 - **`fuzzing`:** Exposes some internal data structures so that they can be used by our fuzzers. This is NOT a stable
   feature / API!
-- **`transport-tls` (default):** Allows TLS transport via [rustls].
 - **`transport-socks5`:** Allow transport via SOCKS5 proxy.
+- **`transport-tls` (default):** Allows TLS transport via [rustls].
 
 ## Testing
 
@@ -245,6 +249,7 @@ e.g. by batching writes to multiple partitions in a single ProduceRequest
 [cargo-criterion]: https://github.com/bheisler/cargo-criterion
 [cargo-fuzz]: https://github.com/rust-fuzz/cargo-fuzz
 [cargo-with]: https://github.com/cbourjau/cargo-with
+[gzip]: https://en.wikipedia.org/wiki/Gzip
 [IOx]: https://github.com/influxdata/influxdb_iox/
 [LLDB]: https://lldb.llvm.org/
 [perf]: https://perf.wiki.kernel.org/index.php/Main_Page

--- a/benches/write_throughput.rs
+++ b/benches/write_throughput.rs
@@ -11,7 +11,7 @@ use futures::{stream::FuturesUnordered, StreamExt};
 use rdkafka::producer::FutureProducer;
 use rskafka::{
     client::{
-        partition::PartitionClient,
+        partition::{Compression, PartitionClient},
         producer::{aggregator::RecordAggregator, BatchProducerBuilder},
         ClientBuilder,
     },
@@ -81,7 +81,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     let start = Instant::now();
 
                     for _ in 0..iters {
-                        client.produce(vec![record.clone()]).await.unwrap();
+                        client
+                            .produce(vec![record.clone()], Compression::NoCompression)
+                            .await
+                            .unwrap();
                     }
 
                     start.elapsed()

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,14 +1,12 @@
 use rskafka::{
     client::{
         error::{Error as ClientError, ProtocolError},
-        partition::PartitionClient,
+        partition::Compression,
         ClientBuilder,
     },
-    record::{Record, RecordAndOffset},
+    record::Record,
 };
 use std::{collections::BTreeMap, str::FromStr, sync::Arc, time::Duration};
-
-mod rdkafka_helper;
 
 mod test_helpers;
 use test_helpers::{now, random_topic_name, record};
@@ -153,27 +151,10 @@ async fn test_produce_empty() {
         .unwrap();
 
     let partition_client = client.partition_client(&topic_name, 1).await.unwrap();
-    partition_client.produce(vec![]).await.unwrap();
-}
-
-#[tokio::test]
-async fn test_produce_rdkafka_consume_rdkafka() {
-    assert_produce_consume(produce_rdkafka, consume_rdkafka).await;
-}
-
-#[tokio::test]
-async fn test_produce_rskafka_consume_rdkafka() {
-    assert_produce_consume(produce_rskafka, consume_rdkafka).await;
-}
-
-#[tokio::test]
-async fn test_produce_rdkafka_consume_rskafka() {
-    assert_produce_consume(produce_rdkafka, consume_rskafka).await;
-}
-
-#[tokio::test]
-async fn test_produce_rskafka_consume_rskafka() {
-    assert_produce_consume(produce_rskafka, consume_rskafka).await;
+    partition_client
+        .produce(vec![], Compression::NoCompression)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -209,12 +190,12 @@ async fn test_get_high_watermark() {
         ..record_early.clone()
     };
     partition_client
-        .produce(vec![record_late.clone()])
+        .produce(vec![record_late.clone()], Compression::NoCompression)
         .await
         .unwrap();
 
     let offsets = partition_client
-        .produce(vec![record_early.clone()])
+        .produce(vec![record_early.clone()], Compression::NoCompression)
         .await
         .unwrap();
     assert_eq!(offsets.len(), 1);
@@ -224,142 +205,6 @@ async fn test_get_high_watermark() {
         partition_client.get_high_watermark().await.unwrap(),
         expected
     );
-}
-
-async fn assert_produce_consume<F1, G1, F2, G2>(f_produce: F1, f_consume: F2)
-where
-    F1: Fn(Arc<PartitionClient>, String, String, i32, Vec<Record>) -> G1,
-    G1: std::future::Future<Output = Vec<i64>>,
-    F2: Fn(Arc<PartitionClient>, String, String, i32, usize) -> G2,
-    G2: std::future::Future<Output = Vec<RecordAndOffset>>,
-{
-    maybe_start_logging();
-
-    let connection = maybe_skip_kafka_integration!();
-    let topic_name = random_topic_name();
-    let n_partitions = 2;
-
-    let client = ClientBuilder::new(vec![connection.clone()])
-        .build()
-        .await
-        .unwrap();
-    let controller_client = client.controller_client().await.unwrap();
-    controller_client
-        .create_topic(&topic_name, n_partitions, 1, 5_000)
-        .await
-        .unwrap();
-    let partition_client = Arc::new(
-        client
-            .partition_client(topic_name.clone(), 1)
-            .await
-            .unwrap(),
-    );
-
-    let record_1 = record();
-    let record_2 = Record {
-        value: b"some value".to_vec(),
-        timestamp: now(),
-        ..record_1.clone()
-    };
-    let record_3 = Record {
-        value: b"more value".to_vec(),
-        timestamp: now(),
-        ..record_1.clone()
-    };
-
-    // produce
-    let mut offsets = vec![];
-    offsets.append(
-        &mut f_produce(
-            Arc::clone(&partition_client),
-            connection.clone(),
-            topic_name.clone(),
-            1,
-            vec![record_1.clone(), record_2.clone()],
-        )
-        .await,
-    );
-    offsets.append(
-        &mut f_produce(
-            Arc::clone(&partition_client),
-            connection.clone(),
-            topic_name.clone(),
-            1,
-            vec![record_3.clone()],
-        )
-        .await,
-    );
-
-    // consume
-    let actual = f_consume(partition_client, connection, topic_name, 1, 3).await;
-    let expected: Vec<_> = offsets
-        .into_iter()
-        .zip([record_1, record_2, record_3])
-        .map(|(offset, record)| RecordAndOffset { record, offset })
-        .collect();
-    assert_eq!(actual, expected);
-}
-
-async fn produce_rdkafka(
-    _partition_client: Arc<PartitionClient>,
-    connection: String,
-    topic_name: String,
-    partition_index: i32,
-    records: Vec<Record>,
-) -> Vec<i64> {
-    rdkafka_helper::produce(
-        &connection,
-        records
-            .into_iter()
-            .map(|record| (topic_name.clone(), partition_index, record))
-            .collect(),
-    )
-    .await
-}
-
-async fn produce_rskafka(
-    partition_client: Arc<PartitionClient>,
-    _connection: String,
-    _topic_name: String,
-    _partition_index: i32,
-    records: Vec<Record>,
-) -> Vec<i64> {
-    partition_client.produce(records).await.unwrap()
-}
-
-async fn consume_rdkafka(
-    _partition_client: Arc<PartitionClient>,
-    connection: String,
-    topic_name: String,
-    partition_index: i32,
-    n: usize,
-) -> Vec<RecordAndOffset> {
-    rdkafka_helper::consume(&connection, &topic_name, partition_index, n).await
-}
-
-async fn consume_rskafka(
-    partition_client: Arc<PartitionClient>,
-    _connection: String,
-    _topic_name: String,
-    _partition_index: i32,
-    n: usize,
-) -> Vec<RecordAndOffset> {
-    // TODO: use a proper stream here
-    let mut records = vec![];
-    let mut offset = 0;
-    while records.len() < n {
-        let res = partition_client
-            .fetch_records(offset, 0..1_000_000, 1_000)
-            .await
-            .unwrap()
-            .0;
-        assert!(!res.is_empty());
-        for record in res {
-            offset = offset.max(record.offset);
-            records.push(record);
-        }
-    }
-    records.into_iter().take(n).collect()
 }
 
 #[tokio::test]
@@ -384,15 +229,15 @@ async fn test_produce_consume_size_cutoff() {
 
     // produce in spearate request so we have three record batches
     partition_client
-        .produce(vec![record_1.clone()])
+        .produce(vec![record_1.clone()], Compression::NoCompression)
         .await
         .unwrap();
     partition_client
-        .produce(vec![record_2.clone()])
+        .produce(vec![record_2.clone()], Compression::NoCompression)
         .await
         .unwrap();
     partition_client
-        .produce(vec![record_3.clone()])
+        .produce(vec![record_3.clone()], Compression::NoCompression)
         .await
         .unwrap();
 

--- a/tests/consumer.rs
+++ b/tests/consumer.rs
@@ -6,6 +6,7 @@ use tokio::time::timeout;
 
 use rskafka::client::{
     consumer::{StreamConsumer, StreamConsumerBuilder},
+    partition::Compression,
     ClientBuilder,
 };
 use test_helpers::{maybe_start_logging, random_topic_name, record};
@@ -30,7 +31,7 @@ async fn test_stream_consumer() {
 
     let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
     partition_client
-        .produce(vec![record.clone()])
+        .produce(vec![record.clone()], Compression::NoCompression)
         .await
         .unwrap();
 
@@ -52,7 +53,10 @@ async fn test_stream_consumer() {
         .expect_err("timeout");
 
     partition_client
-        .produce(vec![record.clone(), record.clone()])
+        .produce(
+            vec![record.clone(), record.clone()],
+            Compression::NoCompression,
+        )
         .await
         .unwrap();
 

--- a/tests/produce_consume.rs
+++ b/tests/produce_consume.rs
@@ -1,0 +1,219 @@
+use std::sync::Arc;
+
+use rskafka::{
+    client::{
+        partition::{Compression, PartitionClient},
+        ClientBuilder,
+    },
+    record::{Record, RecordAndOffset},
+};
+
+mod rdkafka_helper;
+mod test_helpers;
+
+use test_helpers::{maybe_start_logging, now, random_topic_name, record};
+
+#[tokio::test]
+async fn test_produce_rdkafka_consume_rdkafka_nocompression() {
+    assert_produce_consume(produce_rdkafka, consume_rdkafka, Compression::NoCompression).await;
+}
+
+#[tokio::test]
+async fn test_produce_rskafka_consume_rdkafka_nocompression() {
+    assert_produce_consume(produce_rskafka, consume_rdkafka, Compression::NoCompression).await;
+}
+
+#[tokio::test]
+async fn test_produce_rdkafka_consume_rskafka_nocompression() {
+    assert_produce_consume(produce_rdkafka, consume_rskafka, Compression::NoCompression).await;
+}
+
+#[tokio::test]
+async fn test_produce_rskafka_consume_rskafka_nocompression() {
+    assert_produce_consume(produce_rskafka, consume_rskafka, Compression::NoCompression).await;
+}
+
+#[cfg(feature = "compression-gzip")]
+#[tokio::test]
+async fn test_produce_rdkafka_consume_rdkafka_gzip() {
+    assert_produce_consume(produce_rdkafka, consume_rdkafka, Compression::Gzip).await;
+}
+
+#[cfg(feature = "compression-gzip")]
+#[tokio::test]
+async fn test_produce_rskafka_consume_rdkafka_gzip() {
+    assert_produce_consume(produce_rskafka, consume_rdkafka, Compression::Gzip).await;
+}
+
+#[cfg(feature = "compression-gzip")]
+#[tokio::test]
+async fn test_produce_rdkafka_consume_rskafka_gzip() {
+    assert_produce_consume(produce_rdkafka, consume_rskafka, Compression::Gzip).await;
+}
+
+#[cfg(feature = "compression-gzip")]
+#[tokio::test]
+async fn test_produce_rskafka_consume_rskafka_gzip() {
+    assert_produce_consume(produce_rskafka, consume_rskafka, Compression::Gzip).await;
+}
+
+async fn assert_produce_consume<F1, G1, F2, G2>(
+    f_produce: F1,
+    f_consume: F2,
+    compression: Compression,
+) where
+    F1: Fn(Arc<PartitionClient>, String, String, i32, Vec<Record>, Compression) -> G1,
+    G1: std::future::Future<Output = Vec<i64>>,
+    F2: Fn(Arc<PartitionClient>, String, String, i32, usize) -> G2,
+    G2: std::future::Future<Output = Vec<RecordAndOffset>>,
+{
+    maybe_start_logging();
+
+    let connection = maybe_skip_kafka_integration!();
+    let topic_name = random_topic_name();
+    let n_partitions = 2;
+
+    let client = ClientBuilder::new(vec![connection.clone()])
+        .build()
+        .await
+        .unwrap();
+    let controller_client = client.controller_client().await.unwrap();
+    controller_client
+        .create_topic(&topic_name, n_partitions, 1, 5_000)
+        .await
+        .unwrap();
+    let partition_client = Arc::new(
+        client
+            .partition_client(topic_name.clone(), 1)
+            .await
+            .unwrap(),
+    );
+
+    let record_1 = {
+        let record = record();
+        match compression {
+            Compression::NoCompression => record,
+            #[allow(unreachable_patterns)]
+            _ => {
+                // add a bit more data to encourage rdkafka to actually use compression, otherwise the compressed data
+                // is larger than the uncompressed version and rdkafka will not use compression at all
+                Record {
+                    key: vec![b'x'; 100],
+                    ..record
+                }
+            }
+        }
+    };
+    let record_2 = Record {
+        value: b"some value".to_vec(),
+        timestamp: now(),
+        ..record_1.clone()
+    };
+    let record_3 = Record {
+        value: b"more value".to_vec(),
+        timestamp: now(),
+        ..record_1.clone()
+    };
+
+    // produce
+    let mut offsets = vec![];
+    offsets.append(
+        &mut f_produce(
+            Arc::clone(&partition_client),
+            connection.clone(),
+            topic_name.clone(),
+            1,
+            vec![record_1.clone(), record_2.clone()],
+            compression,
+        )
+        .await,
+    );
+    offsets.append(
+        &mut f_produce(
+            Arc::clone(&partition_client),
+            connection.clone(),
+            topic_name.clone(),
+            1,
+            vec![record_3.clone()],
+            compression,
+        )
+        .await,
+    );
+
+    // consume
+    let actual = f_consume(partition_client, connection, topic_name, 1, 3).await;
+    let expected: Vec<_> = offsets
+        .into_iter()
+        .zip([record_1, record_2, record_3])
+        .map(|(offset, record)| RecordAndOffset { record, offset })
+        .collect();
+    assert_eq!(actual, expected);
+}
+
+async fn produce_rdkafka(
+    _partition_client: Arc<PartitionClient>,
+    connection: String,
+    topic_name: String,
+    partition_index: i32,
+    records: Vec<Record>,
+    compression: Compression,
+) -> Vec<i64> {
+    rdkafka_helper::produce(
+        &connection,
+        records
+            .into_iter()
+            .map(|record| (topic_name.clone(), partition_index, record))
+            .collect(),
+        compression,
+    )
+    .await
+}
+
+async fn produce_rskafka(
+    partition_client: Arc<PartitionClient>,
+    _connection: String,
+    _topic_name: String,
+    _partition_index: i32,
+    records: Vec<Record>,
+    compression: Compression,
+) -> Vec<i64> {
+    partition_client
+        .produce(records, compression)
+        .await
+        .unwrap()
+}
+
+async fn consume_rdkafka(
+    _partition_client: Arc<PartitionClient>,
+    connection: String,
+    topic_name: String,
+    partition_index: i32,
+    n: usize,
+) -> Vec<RecordAndOffset> {
+    rdkafka_helper::consume(&connection, &topic_name, partition_index, n).await
+}
+
+async fn consume_rskafka(
+    partition_client: Arc<PartitionClient>,
+    _connection: String,
+    _topic_name: String,
+    _partition_index: i32,
+    n: usize,
+) -> Vec<RecordAndOffset> {
+    // TODO: use a proper stream here
+    let mut records = vec![];
+    let mut offset = 0;
+    while records.len() < n {
+        let res = partition_client
+            .fetch_records(offset, 0..1_000_000, 1_000)
+            .await
+            .unwrap()
+            .0;
+        assert!(!res.is_empty());
+        for record in res {
+            offset = offset.max(record.offset);
+            records.push(record);
+        }
+    }
+    records.into_iter().take(n).collect()
+}

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -78,12 +78,15 @@ pub fn maybe_start_logging() {
 
 /// Start logging.
 pub fn start_logging() {
+    use tracing_log::LogTracer;
     use tracing_subscriber::{filter::EnvFilter, FmtSubscriber};
 
     LOG_SETUP.call_once(|| {
+        LogTracer::init().unwrap();
+
         let subscriber = FmtSubscriber::builder()
             .with_env_filter(EnvFilter::from_default_env())
-            .with_writer(std::io::stderr)
+            .with_test_writer()
             .finish();
 
         tracing::subscriber::set_global_default(subscriber)


### PR DESCRIPTION
While we technically don't want to emit compressed data for IOx, I'm worried that some backup / cluster tool will compress our messages anyways and we end up in some incident not being able to read the data any longer.

The primary contribution of this PR is to figure out how compression works. Adding more types can be done later and should be rather easy, since they all follow the same pattern (i.e. a compressed block that follows the number of records).