### PR TITLE
fix: `retry_with_backup` takes error for "continue"

### DIFF
--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -92,15 +92,15 @@ impl Backoff {
     // TODO: Currently, this can't fail, but there should be a global maximum timeout that
     // causes an error if the total time retrying exceeds that amount.
     // See https://github.com/influxdata/rskafka/issues/65
-    pub async fn retry_with_backoff<F, F1, B, C>(
+    pub async fn retry_with_backoff<F, F1, B, E>(
         &mut self,
         request_name: &str,
         do_stuff: F,
     ) -> BackoffResult<B>
     where
         F: (Fn() -> F1) + Send + Sync,
-        F1: std::future::Future<Output = ControlFlow<B, C>> + Send,
-        C: core::fmt::Display + Send,
+        F1: std::future::Future<Output = ControlFlow<B, E>> + Send,
+        E: std::error::Error + Send,
     {
         loop {
             let e = match do_stuff().await {

--- a/src/client/controller.rs
+++ b/src/client/controller.rs
@@ -165,7 +165,7 @@ where
                     return ControlFlow::Break(Err(error));
                 }
             }
-            ControlFlow::Continue(request_name)
+            ControlFlow::Continue(error)
         })
         .await
         .map_err(Error::RetryFailed)?

--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -298,7 +298,7 @@ where
                 }
             }
 
-            ControlFlow::Continue(request_name)
+            ControlFlow::Continue(error)
         })
         .await
         .map_err(Error::RetryFailed)?

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -336,7 +336,12 @@ where
 
                 return ControlFlow::Break(connection);
             }
-            ControlFlow::Continue("Failed to connect to any broker, backing off")
+
+            let err = Box::<dyn std::error::Error + Send + Sync>::from(
+                "Failed to connect to any broker, backing off".to_string(),
+            );
+            let err: Arc<dyn std::error::Error + Send + Sync> = err.into();
+            ControlFlow::Continue(err)
         })
         .await
         .map_err(Error::RetryFailed)


### PR DESCRIPTION
I think this was always meant to be this way because the request name is
passed as an argument, but this got somehow mixed up in the meantime and
now we don't probably report non-fatal errors anymore. To prevent this
in the future this tightens the type bounds a bit.
