### PR TITLE
chore: build docs with `--all-features`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
       - cache_restore
       - run:
           name: Cargo doc
-          command: cargo doc --document-private-items --no-deps --workspace
+          command: cargo doc --all-features --document-private-items --no-deps --workspace
       - cache_save
       - run:
           name: Compress Docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,6 @@ members = [
     ".",
     "fuzz",
 ]
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
We already test that `--all-features` builds in CI, so we can also
publish feature-complete docs.
