### PR TITLE
fix: record key/value can be NULL

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ let partition_client = client
 
 // produce some data
 let record = Record {
-    key: b"".to_vec(),
-    value: b"hello kafka".to_vec(),
+    key: None,
+    value: Some(b"hello kafka".to_vec()),
     headers: BTreeMap::from([
         ("foo".to_owned(), b"bar".to_vec()),
     ]),

--- a/benches/write_throughput.rs
+++ b/benches/write_throughput.rs
@@ -72,8 +72,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 async move {
                     let client = setup_rskafka(connection).await;
                     let record = Record {
-                        key,
-                        value,
+                        key: Some(key),
+                        value: Some(value),
                         headers: BTreeMap::default(),
                         timestamp: OffsetDateTime::now_utc(),
                     };
@@ -139,8 +139,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 async move {
                     let client = setup_rskafka(connection).await;
                     let record = Record {
-                        key,
-                        value,
+                        key: Some(key),
+                        value: Some(value),
                         headers: BTreeMap::default(),
                         timestamp: OffsetDateTime::now_utc(),
                     };

--- a/src/client/consumer.rs
+++ b/src/client/consumer.rs
@@ -351,8 +351,8 @@ mod tests {
     #[tokio::test]
     async fn test_consumer() {
         let record = Record {
-            key: vec![0; 4],
-            value: vec![0; 6],
+            key: Some(vec![0; 4]),
+            value: Some(vec![0; 6]),
             headers: Default::default(),
             timestamp: OffsetDateTime::now_utc(),
         };
@@ -412,8 +412,8 @@ mod tests {
     #[tokio::test]
     async fn test_consumer_timeout() {
         let record = Record {
-            key: vec![0; 4],
-            value: vec![0; 6],
+            key: Some(vec![0; 4]),
+            value: Some(vec![0; 6]),
             headers: Default::default(),
             timestamp: OffsetDateTime::now_utc(),
         };

--- a/src/client/producer.rs
+++ b/src/client/producer.rs
@@ -72,8 +72,8 @@
 //!
 //! // produce data
 //! let record = Record {
-//!     key: b"".to_vec(),
-//!     value: b"hello kafka".to_vec(),
+//!     key: None,
+//!     value: Some(b"hello kafka".to_vec()),
 //!     headers: BTreeMap::from([
 //!         ("foo".to_owned(), b"bar".to_vec()),
 //!     ]),
@@ -145,8 +145,8 @@
 //!         let data = std::mem::take(&mut self.data);
 //!         let records = vec![
 //!             Record {
-//!                 key: b"".to_vec(),
-//!                 value: data,
+//!                 key: None,
+//!                 value: Some(data),
 //!                 headers: BTreeMap::from([
 //!                     ("foo".to_owned(), b"bar".to_vec()),
 //!                 ]),
@@ -542,8 +542,8 @@ mod tests {
 
     fn record() -> Record {
         Record {
-            key: vec![0; 4],
-            value: vec![0; 6],
+            key: Some(vec![0; 4]),
+            value: Some(vec![0; 6]),
             headers: Default::default(),
             timestamp: OffsetDateTime::from_unix_timestamp(320).unwrap(),
         }

--- a/src/client/producer/aggregator.rs
+++ b/src/client/producer/aggregator.rs
@@ -149,14 +149,14 @@ mod tests {
     #[test]
     fn test_record_aggregator() {
         let r1 = Record {
-            key: vec![0; 45],
-            value: vec![0; 2],
+            key: Some(vec![0; 45]),
+            value: Some(vec![0; 2]),
             headers: Default::default(),
             timestamp: OffsetDateTime::from_unix_timestamp(20).unwrap(),
         };
 
         let r2 = Record {
-            value: vec![0; 34],
+            value: Some(vec![0; 34]),
             ..r1.clone()
         };
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -5,8 +5,8 @@ use time::OffsetDateTime;
 /// High-level record.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Record {
-    pub key: Vec<u8>,
-    pub value: Vec<u8>,
+    pub key: Option<Vec<u8>>,
+    pub value: Option<Vec<u8>>,
     pub headers: BTreeMap<String, Vec<u8>>,
     pub timestamp: OffsetDateTime,
 }
@@ -14,8 +14,8 @@ pub struct Record {
 impl Record {
     /// Returns the approximate uncompressed size of this [`Record`]
     pub fn approximate_size(&self) -> usize {
-        self.key.len()
-            + self.value.len()
+        self.key.as_ref().map(|k| k.len()).unwrap_or_default()
+            + self.value.as_ref().map(|v| v.len()).unwrap_or_default()
             + self
                 .headers
                 .iter()
@@ -38,8 +38,8 @@ mod tests {
     #[test]
     fn test_approximate_size() {
         let record = Record {
-            key: vec![0; 23],
-            value: vec![0; 45],
+            key: Some(vec![0; 23]),
+            value: Some(vec![0; 45]),
             headers: vec![("a".to_string(), vec![0; 5]), ("b".to_string(), vec![0; 7])]
                 .into_iter()
                 .collect(),

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -282,8 +282,8 @@ async fn test_produce_consume_size_cutoff() {
 
 pub fn large_record() -> Record {
     Record {
-        key: b"".to_vec(),
-        value: vec![b'x'; 1024],
+        key: Some(b"".to_vec()),
+        value: Some(vec![b'x'; 1024]),
         headers: BTreeMap::from([("foo".to_owned(), b"bar".to_vec())]),
         timestamp: now(),
     }

--- a/tests/produce_consume.rs
+++ b/tests/produce_consume.rs
@@ -146,19 +146,19 @@ async fn assert_produce_consume<F1, G1, F2, G2>(
                 // add a bit more data to encourage rdkafka to actually use compression, otherwise the compressed data
                 // is larger than the uncompressed version and rdkafka will not use compression at all
                 Record {
-                    key: vec![b'x'; 100],
+                    key: Some(vec![b'x'; 100]),
                     ..record
                 }
             }
         }
     };
     let record_2 = Record {
-        value: b"some value".to_vec(),
+        value: Some(b"some value".to_vec()),
         timestamp: now(),
         ..record_1.clone()
     };
     let record_3 = Record {
-        value: b"more value".to_vec(),
+        value: Some(b"more value".to_vec()),
         timestamp: now(),
         ..record_1.clone()
     };

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -51,8 +51,8 @@ pub fn random_topic_name() -> String {
 
 pub fn record() -> Record {
     Record {
-        key: b"".to_vec(),
-        value: b"hello kafka".to_vec(),
+        key: Some(b"".to_vec()),
+        value: Some(b"hello kafka".to_vec()),
         headers: BTreeMap::from([("foo".to_owned(), b"bar".to_vec())]),
         timestamp: now(),
     }


### PR DESCRIPTION
In the NULL case (which can be produced by rdkafka) the length of these
fields is set to -1.
