### PR TITLE
fix: terminate consumer stream on `OffsetOutOfRange`

### DIFF
--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -105,6 +105,11 @@ impl PartitionClient {
     /// Fetch `bytes` bytes of record data starting at sequence number `offset`
     ///
     /// Returns the records, and the current high watermark.
+    ///
+    ///
+    /// # Error Handling
+    /// Fetching records outside the range known the to broker (marked by low and high watermark) will lead to a
+    /// [`ServerError`](Error::ServerError) with [`OffsetOutOfRange`](ProtocolError::OffsetOutOfRange).
     pub async fn fetch_records(
         &self,
         offset: i64,

--- a/tests/consumer.rs
+++ b/tests/consumer.rs
@@ -37,7 +37,9 @@ async fn test_stream_consumer() {
         .await
         .unwrap();
 
-    let mut stream = StreamConsumerBuilder::new(Arc::clone(&partition_client), 0).build();
+    let mut stream = StreamConsumerBuilder::new(Arc::clone(&partition_client), 0)
+        .with_max_wait_ms(50)
+        .build();
 
     let assert_ok =
         |r: Result<Option<<StreamConsumer as Stream>::Item>, tokio::time::error::Elapsed>| {
@@ -50,7 +52,7 @@ async fn test_stream_consumer() {
     assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
 
     // No further records
-    timeout(Duration::from_millis(100), stream.next())
+    timeout(Duration::from_millis(200), stream.next())
         .await
         .expect_err("timeout");
 


### PR DESCRIPTION
If we encounter `OffsetOutOfRange` this means that the start offset of
the stream lies outside of the range that Kafka knows. In this case we
should not hot-loop and try to poll new data forever, since this is very
likely NOT intended.

The only use case I could come up with is to start a stream at some "yet
to be produced" offset, but I fail to come up with a practical reasoning
behind this as well as a method to dermine the start offset for such a
use case.

So most users are likely interested to subscribe to data that already
exists within the system.
