### PR TITLE
feat: allow `StreamConsumer` to start at "earliest"/"latest" offset

### DIFF
--- a/src/client/consumer.rs
+++ b/src/client/consumer.rs
@@ -651,7 +651,7 @@ mod tests {
 
         assert_stream_pending(&mut stream).await;
 
-        // Write two records, nothing should happen as start offset is 2 (via "earlist")
+        // Write two records, nothing should happen as start offset is 2 (via "earliest")
         sender.send(record.clone()).await.unwrap();
         sender.send(record.clone()).await.unwrap();
 
@@ -694,7 +694,7 @@ mod tests {
 
         assert_stream_pending(&mut stream).await;
 
-        // Write two records, nothing should happen as start offset is 2 (via "earlist")
+        // Write two records, nothing should happen as start offset is 2 (via "latest")
         sender.send(record.clone()).await.unwrap();
         sender.send(record.clone()).await.unwrap();
 

--- a/src/client/consumer.rs
+++ b/src/client/consumer.rs
@@ -148,13 +148,13 @@ impl StreamConsumerBuilder {
     }
 }
 
-struct FetchResultInner {
+struct FetchResultOk {
     records_and_offsets: Vec<RecordAndOffset>,
     watermark: i64,
     used_offset: i64,
 }
 
-type FetchResult = Result<FetchResultInner>;
+type FetchResult = Result<FetchResultOk>;
 
 /// A trait wrapper to allow mocking
 trait FetchClient: std::fmt::Debug + Send + Sync {
@@ -252,7 +252,7 @@ impl Stream for StreamConsumer {
 
                     let (records_and_offsets, watermark) =
                         client.fetch_records(offset, bytes, max_wait_ms).await?;
-                    Ok(FetchResultInner {
+                    Ok(FetchResultOk {
                         records_and_offsets,
                         watermark,
                         used_offset: offset,
@@ -264,7 +264,7 @@ impl Stream for StreamConsumer {
 
             match (data, *this.start_offset) {
                 (Ok(inner), _) => {
-                    let FetchResultInner {
+                    let FetchResultOk {
                         mut records_and_offsets,
                         watermark,
                         used_offset,

--- a/src/client/consumer.rs
+++ b/src/client/consumer.rs
@@ -6,7 +6,10 @@
 //! use futures::StreamExt;
 //! use rskafka::client::{
 //!     ClientBuilder,
-//!     consumer::StreamConsumerBuilder,
+//!     consumer::{
+//!         StartOffset,
+//!         StreamConsumerBuilder,
+//!     },
 //! };
 //! use std::sync::Arc;
 //!
@@ -20,7 +23,7 @@
 //! // construct stream consumer
 //! let mut stream = StreamConsumerBuilder::new(
 //!         partition_client,
-//!         0,  // start offset
+//!         StartOffset::Earliest,
 //!     )
 //!     .with_max_wait_ms(100)
 //!     .build();
@@ -45,15 +48,40 @@ use pin_project_lite::pin_project;
 use tracing::trace;
 
 use crate::{
-    client::{error::Result, partition::PartitionClient},
+    client::{
+        error::{Error, ProtocolError, Result},
+        partition::PartitionClient,
+    },
     record::RecordAndOffset,
 };
+
+use super::partition::OffsetAt;
+
+/// At which position shall the stream start.
+#[derive(Debug, Clone, Copy)]
+pub enum StartOffset {
+    /// At the earlist known offset.
+    ///
+    /// This might be larger than 0 if some records were already deleted due to a retention policy.
+    Earliest,
+
+    /// At the latest known offset.
+    ///
+    /// This is helpful if you only want ot process new data.
+    Latest,
+
+    /// At a specific offset.
+    ///
+    /// Note that specifying an offset that is unknown to the broker will result in a [`Error::ServerError`] with
+    /// [`ProtocolError::OffsetOutOfRange`] and the stream will terminate right after the error.
+    At(i64),
+}
 
 #[derive(Debug)]
 pub struct StreamConsumerBuilder {
     client: Arc<dyn FetchClient>,
 
-    start_offset: i64,
+    start_offset: StartOffset,
 
     max_wait_ms: i32,
 
@@ -63,12 +91,12 @@ pub struct StreamConsumerBuilder {
 }
 
 impl StreamConsumerBuilder {
-    pub fn new(client: Arc<PartitionClient>, start_offset: i64) -> Self {
+    pub fn new(client: Arc<PartitionClient>, start_offset: StartOffset) -> Self {
         Self::new_with_client(client, start_offset)
     }
 
     /// Internal API for creating with any `dyn FetchClient`
-    fn new_with_client(client: Arc<dyn FetchClient>, start_offset: i64) -> Self {
+    fn new_with_client(client: Arc<dyn FetchClient>, start_offset: StartOffset) -> Self {
         Self {
             client,
             start_offset,
@@ -110,7 +138,8 @@ impl StreamConsumerBuilder {
             max_wait_ms: self.max_wait_ms,
             min_batch_size: self.min_batch_size,
             max_batch_size: self.max_batch_size,
-            next_offset: self.start_offset,
+            next_offset: None,
+            start_offset: self.start_offset,
             terminated: false,
             last_high_watermark: -1,
             buffer: Default::default(),
@@ -119,7 +148,13 @@ impl StreamConsumerBuilder {
     }
 }
 
-type FetchResult = Result<(Vec<RecordAndOffset>, i64)>;
+struct FetchResultInner {
+    records_and_offsets: Vec<RecordAndOffset>,
+    watermark: i64,
+    used_offset: i64,
+}
+
+type FetchResult = Result<FetchResultInner>;
 
 /// A trait wrapper to allow mocking
 trait FetchClient: std::fmt::Debug + Send + Sync {
@@ -132,6 +167,11 @@ trait FetchClient: std::fmt::Debug + Send + Sync {
         bytes: Range<i32>,
         max_wait_ms: i32,
     ) -> BoxFuture<'_, Result<(Vec<RecordAndOffset>, i64)>>;
+
+    /// Get offset.
+    ///
+    /// Arguments are identical to [`PartitionClient::get_offset`].
+    fn get_offset(&self, at: OffsetAt) -> BoxFuture<'_, Result<i64>>;
 }
 
 impl FetchClient for PartitionClient {
@@ -142,6 +182,10 @@ impl FetchClient for PartitionClient {
         max_wait_ms: i32,
     ) -> BoxFuture<'_, Result<(Vec<RecordAndOffset>, i64)>> {
         Box::pin(self.fetch_records(offset, bytes, max_wait_ms))
+    }
+
+    fn get_offset(&self, at: OffsetAt) -> BoxFuture<'_, Result<i64>> {
+        Box::pin(self.get_offset(at))
     }
 }
 
@@ -160,7 +204,9 @@ pin_project! {
 
         max_wait_ms: i32,
 
-        next_offset: i64,
+        start_offset: StartOffset,
+
+        next_offset: Option<i64>,
 
         terminated: bool,
 
@@ -186,38 +232,74 @@ impl Stream for StreamConsumer {
             }
 
             if this.fetch_fut.is_terminated() {
-                let offset = *this.next_offset;
+                let next_offset = *this.next_offset;
+                let start_offset = *this.start_offset;
                 let bytes = (*this.min_batch_size)..(*this.max_batch_size);
                 let max_wait_ms = *this.max_wait_ms;
                 let client = Arc::clone(this.client);
 
-                trace!(offset, "Fetching records at offset");
+                trace!(?start_offset, ?next_offset, "Fetching records at offset");
 
                 *this.fetch_fut = FutureExt::fuse(Box::pin(async move {
-                    client.fetch_records(offset, bytes, max_wait_ms).await
+                    let offset = match next_offset {
+                        Some(x) => x,
+                        None => match start_offset {
+                            StartOffset::Earliest => client.get_offset(OffsetAt::Earliest).await?,
+                            StartOffset::Latest => dbg!(client.get_offset(OffsetAt::Latest).await?),
+                            StartOffset::At(x) => x,
+                        },
+                    };
+
+                    let (records_and_offsets, watermark) =
+                        client.fetch_records(offset, bytes, max_wait_ms).await?;
+                    Ok(FetchResultInner {
+                        records_and_offsets,
+                        watermark,
+                        used_offset: offset,
+                    })
                 }));
             }
 
             let data: FetchResult = futures::ready!(this.fetch_fut.poll_unpin(cx));
 
-            match data {
-                Ok((mut v, watermark)) => {
+            match (data, *this.start_offset) {
+                (Ok(inner), _) => {
+                    let FetchResultInner {
+                        mut records_and_offsets,
+                        watermark,
+                        used_offset,
+                    } = inner;
                     trace!(
                         high_watermark = watermark,
-                        n_records = v.len(),
+                        n_records = records_and_offsets.len(),
                         "Received records and a high watermark",
                     );
 
+                    // Remember used offset (might be overwritten if there was any data) so we don't refetch the
+                    // earliest / latest offset for every try. Also fetching the latest offset might be racy otherwise,
+                    // since we'll never be in a position where the latest one can actually be fetched.
+                    *this.next_offset = Some(used_offset);
+
                     // Sort records by offset in case they aren't in order
-                    v.sort_by_key(|x| x.offset);
+                    records_and_offsets.sort_by_key(|x| x.offset);
                     *this.last_high_watermark = watermark;
-                    if let Some(x) = v.last() {
-                        *this.next_offset = x.offset + 1;
-                        this.buffer.extend(v.into_iter())
+                    if let Some(x) = records_and_offsets.last() {
+                        *this.next_offset = Some(x.offset + 1);
+                        this.buffer.extend(records_and_offsets.into_iter())
                     }
                     continue;
                 }
-                Err(e) => {
+                // if we don't have an offset, try again because fetching the offset is racy
+                (
+                    Err(Error::ServerError(ProtocolError::OffsetOutOfRange, _)),
+                    StartOffset::Earliest | StartOffset::Latest,
+                ) => {
+                    // wipe offset and try again
+                    *this.next_offset = None;
+                    continue;
+                }
+                // if we have an offset, terminate the stream
+                (Err(e), _) => {
                     *this.terminated = true;
 
                     // report error once
@@ -268,16 +350,20 @@ mod tests {
     struct MockFetchInner {
         batch_sizes: Vec<usize>,
         stream: mpsc::Receiver<Record>,
+        next_err: Option<Error>,
         buffer: Vec<Record>,
+        range: (i64, i64),
     }
 
     impl MockFetch {
-        fn new(stream: mpsc::Receiver<Record>) -> Self {
+        fn new(stream: mpsc::Receiver<Record>, next_err: Option<Error>, range: (i64, i64)) -> Self {
             Self {
                 inner: Arc::new(Mutex::new(MockFetchInner {
                     batch_sizes: vec![],
                     stream,
                     buffer: Default::default(),
+                    next_err,
+                    range,
                 })),
             }
         }
@@ -296,6 +382,10 @@ mod tests {
         ) -> BoxFuture<'_, Result<(Vec<RecordAndOffset>, i64)>> {
             let inner = Arc::clone(&self.inner);
             Box::pin(async move {
+                if let Some(err) = inner.lock().await.next_err.take() {
+                    return Err(err);
+                }
+
                 println!("MockFetch::fetch_records");
                 let mut inner = inner.lock().await;
                 println!("MockFetch::fetch_records locked");
@@ -370,33 +460,14 @@ mod tests {
                 Ok((buffer, inner.buffer.len() as i64 - 1))
             })
         }
-    }
 
-    #[derive(Debug)]
-    struct MockErrFetch {
-        inner: Arc<Mutex<Option<Error>>>,
-    }
-
-    impl MockErrFetch {
-        fn new(e: Error) -> Self {
-            Self {
-                inner: Arc::new(Mutex::new(Some(e))),
-            }
-        }
-    }
-
-    impl FetchClient for MockErrFetch {
-        fn fetch_records(
-            &self,
-            _offset: i64,
-            _bytes: Range<i32>,
-            _max_wait_ms: i32,
-        ) -> BoxFuture<'_, Result<(Vec<RecordAndOffset>, i64)>> {
+        fn get_offset(&self, at: OffsetAt) -> BoxFuture<'_, Result<i64>> {
             let inner = Arc::clone(&self.inner);
+
             Box::pin(async move {
-                match inner.lock().await.take() {
-                    Some(e) => Err(e),
-                    None => panic!("EOF"),
+                match at {
+                    OffsetAt::Earliest => Ok(inner.lock().await.range.0),
+                    OffsetAt::Latest => Ok(inner.lock().await.range.1),
                 }
             })
         }
@@ -412,23 +483,21 @@ mod tests {
         };
 
         let (sender, receiver) = mpsc::channel(10);
-        let consumer = Arc::new(MockFetch::new(receiver));
-        let mut stream =
-            StreamConsumerBuilder::new_with_client(Arc::<MockFetch>::clone(&consumer), 2)
-                .with_max_wait_ms(10)
-                .build();
+        let consumer = Arc::new(MockFetch::new(receiver, None, (0, 1_000)));
+        let mut stream = StreamConsumerBuilder::new_with_client(
+            Arc::<MockFetch>::clone(&consumer),
+            StartOffset::At(2),
+        )
+        .with_max_wait_ms(10)
+        .build();
 
-        tokio::time::timeout(Duration::from_micros(1), stream.next())
-            .await
-            .expect_err("timeout");
+        assert_stream_pending(&mut stream).await;
 
         // Write two records, nothing should happen as start offset is 2
         sender.send(record.clone()).await.unwrap();
         sender.send(record.clone()).await.unwrap();
 
-        tokio::time::timeout(Duration::from_micros(10), stream.next())
-            .await
-            .expect_err("timeout");
+        assert_stream_pending(&mut stream).await;
 
         sender.send(record.clone()).await.unwrap();
 
@@ -481,21 +550,21 @@ mod tests {
         };
 
         let (sender, receiver) = mpsc::channel(10);
-        let consumer = Arc::new(MockFetch::new(receiver));
+        let consumer = Arc::new(MockFetch::new(receiver, None, (0, 1_000)));
 
         assert!(consumer.batch_sizes().await.is_empty());
 
-        let mut stream =
-            StreamConsumerBuilder::new_with_client(Arc::<MockFetch>::clone(&consumer), 0)
-                .with_min_batch_size((record.approximate_size() * 2) as i32)
-                .with_max_batch_size((record.approximate_size() * 3) as i32)
-                .with_max_wait_ms(1)
-                .build();
+        let mut stream = StreamConsumerBuilder::new_with_client(
+            Arc::<MockFetch>::clone(&consumer),
+            StartOffset::At(0),
+        )
+        .with_min_batch_size((record.approximate_size() * 2) as i32)
+        .with_max_batch_size((record.approximate_size() * 3) as i32)
+        .with_max_wait_ms(5)
+        .build();
 
         // Should return nothing
-        tokio::time::timeout(Duration::from_millis(10), stream.next())
-            .await
-            .expect_err("timeout");
+        assert_stream_pending(&mut stream).await;
 
         // Stream might be holding lock, so must poll it whilst trying to extract batch sizes
         // to allow timeouts to be serviced and the lock released
@@ -521,13 +590,13 @@ mod tests {
         sender.send(record.clone()).await.unwrap();
 
         // Should not wait for max_wait_ms
-        tokio::time::timeout(Duration::from_micros(10), stream.next())
+        tokio::time::timeout(Duration::from_micros(1), stream.next())
             .await
             .unwrap()
             .unwrap()
             .unwrap();
         // Should not wait for max_wait_ms
-        tokio::time::timeout(Duration::from_micros(10), stream.next())
+        tokio::time::timeout(Duration::from_micros(1), stream.next())
             .await
             .unwrap()
             .unwrap()
@@ -540,9 +609,11 @@ mod tests {
             ProtocolError::OffsetOutOfRange,
             String::from("offset out of range"),
         );
-        let consumer = Arc::new(MockErrFetch::new(e));
+        let (_sender, receiver) = mpsc::channel(10);
+        let consumer = Arc::new(MockFetch::new(receiver, Some(e), (0, 1_000)));
 
-        let mut stream = StreamConsumerBuilder::new_with_client(consumer, 0).build();
+        let mut stream =
+            StreamConsumerBuilder::new_with_client(consumer, StartOffset::At(0)).build();
 
         let error = stream.next().await.expect("stream not empty").unwrap_err();
         assert_matches!(
@@ -552,5 +623,105 @@ mod tests {
 
         // stream ends
         assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_consumer_earliest() {
+        let record = Record {
+            key: Some(vec![0; 4]),
+            value: Some(vec![0; 6]),
+            headers: Default::default(),
+            timestamp: OffsetDateTime::now_utc(),
+        };
+
+        // Simulate an error on first fetch to encourage an offset update
+        let e = Error::ServerError(
+            ProtocolError::OffsetOutOfRange,
+            String::from("offset out of range"),
+        );
+
+        let (sender, receiver) = mpsc::channel(10);
+        let consumer = Arc::new(MockFetch::new(receiver, Some(e), (2, 1_000)));
+        let mut stream = StreamConsumerBuilder::new_with_client(
+            Arc::<MockFetch>::clone(&consumer),
+            StartOffset::Earliest,
+        )
+        .with_max_wait_ms(10)
+        .build();
+
+        assert_stream_pending(&mut stream).await;
+
+        // Write two records, nothing should happen as start offset is 2 (via "earlist")
+        sender.send(record.clone()).await.unwrap();
+        sender.send(record.clone()).await.unwrap();
+
+        assert_stream_pending(&mut stream).await;
+
+        sender.send(record.clone()).await.unwrap();
+
+        let unwrap = |e: Result<Option<Result<_, _>>, _>| e.unwrap().unwrap().unwrap();
+
+        let (record_and_offset, high_watermark) =
+            unwrap(tokio::time::timeout(Duration::from_micros(10), stream.next()).await);
+
+        assert_eq!(record_and_offset.offset, 2);
+        assert_eq!(high_watermark, 2);
+    }
+
+    #[tokio::test]
+    async fn test_consumer_latest() {
+        let record = Record {
+            key: Some(vec![0; 4]),
+            value: Some(vec![0; 6]),
+            headers: Default::default(),
+            timestamp: OffsetDateTime::now_utc(),
+        };
+
+        // Simulate an error on first fetch to encourage an offset update
+        let e = Error::ServerError(
+            ProtocolError::OffsetOutOfRange,
+            String::from("offset out of range"),
+        );
+
+        let (sender, receiver) = mpsc::channel(10);
+        let consumer = Arc::new(MockFetch::new(receiver, Some(e), (0, 2)));
+        let mut stream = StreamConsumerBuilder::new_with_client(
+            Arc::<MockFetch>::clone(&consumer),
+            StartOffset::Latest,
+        )
+        .with_max_wait_ms(10)
+        .build();
+
+        assert_stream_pending(&mut stream).await;
+
+        // Write two records, nothing should happen as start offset is 2 (via "earlist")
+        sender.send(record.clone()).await.unwrap();
+        sender.send(record.clone()).await.unwrap();
+
+        assert_stream_pending(&mut stream).await;
+
+        sender.send(record.clone()).await.unwrap();
+
+        let unwrap = |e: Result<Option<Result<_, _>>, _>| e.unwrap().unwrap().unwrap();
+
+        let (record_and_offset, high_watermark) =
+            unwrap(tokio::time::timeout(Duration::from_micros(10), stream.next()).await);
+
+        assert_eq!(record_and_offset.offset, 2);
+        assert_eq!(high_watermark, 2);
+    }
+
+    /// Assert that given stream is pending.
+    ///
+    /// This will will try to poll the stream for a bit to ensure that async IO has a chance to catch up.
+    async fn assert_stream_pending<S>(stream: &mut S)
+    where
+        S: Stream + Send + Unpin,
+        S::Item: std::fmt::Debug,
+    {
+        tokio::select! {
+            e = stream.next() => panic!("stream is not pending, yielded: {e:?}"),
+            _ = tokio::time::sleep(Duration::from_millis(1)) => {},
+        };
     }
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -198,7 +198,7 @@ async fn test_consume_offset_out_of_range() {
         .unwrap();
 
     let partition_client = client.partition_client(&topic_name, 1).await.unwrap();
-    let record = record();
+    let record = record(b"");
     let offsets = partition_client
         .produce(vec![record], Compression::NoCompression)
         .await
@@ -252,7 +252,7 @@ async fn test_get_offset() {
 
     // add some data
     // use out-of order timestamps to ensure our "lastest offset" logic works
-    let record_early = record();
+    let record_early = record(b"");
     let record_late = Record {
         timestamp: record_early.timestamp + time::Duration::SECOND,
         ..record_early.clone()
@@ -373,12 +373,8 @@ async fn test_consume_midbatch() {
     let partition_client = client.partition_client(&topic_name, 0).await.unwrap();
 
     // produce two records into a single batch
-    let record_1 = record();
-    let record_2 = Record {
-        value: Some(b"x".to_vec()),
-        timestamp: now(),
-        ..record_1.clone()
-    };
+    let record_1 = record(b"x");
+    let record_2 = record(b"y");
 
     let offsets = partition_client
         .produce(
@@ -425,22 +421,10 @@ async fn test_delete_records() {
     // - record_1
     // - record_2, record_3
     // - record_4
-    let record_1 = record();
-    let record_2 = Record {
-        value: Some(b"x".to_vec()),
-        timestamp: now(),
-        ..record_1.clone()
-    };
-    let record_3 = Record {
-        value: Some(b"y".to_vec()),
-        timestamp: now(),
-        ..record_1.clone()
-    };
-    let record_4 = Record {
-        value: Some(b"z".to_vec()),
-        timestamp: now(),
-        ..record_1.clone()
-    };
+    let record_1 = record(b"");
+    let record_2 = record(b"x");
+    let record_3 = record(b"y");
+    let record_4 = record(b"z");
 
     let offsets = partition_client
         .produce(vec![record_1.clone()], Compression::NoCompression)

--- a/tests/consumer.rs
+++ b/tests/consumer.rs
@@ -5,18 +5,21 @@ use assert_matches::assert_matches;
 use futures::{Stream, StreamExt};
 use tokio::time::timeout;
 
-use rskafka::client::{
-    consumer::{StreamConsumer, StreamConsumerBuilder},
-    error::{Error, ProtocolError},
-    partition::Compression,
-    ClientBuilder,
+use rskafka::{
+    client::{
+        consumer::{StartOffset, StreamConsumer, StreamConsumerBuilder},
+        error::{Error, ProtocolError},
+        partition::Compression,
+        ClientBuilder,
+    },
+    record::RecordAndOffset,
 };
 use test_helpers::{maybe_start_logging, random_topic_name, record};
 
 mod test_helpers;
 
 #[tokio::test]
-async fn test_stream_consumer() {
+async fn test_stream_consumer_start_at_0() {
     maybe_start_logging();
 
     let connection = maybe_skip_kafka_integration!();
@@ -29,7 +32,7 @@ async fn test_stream_consumer() {
         .await
         .unwrap();
 
-    let record = record();
+    let record = record(b"x");
 
     let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
     partition_client
@@ -37,24 +40,15 @@ async fn test_stream_consumer() {
         .await
         .unwrap();
 
-    let mut stream = StreamConsumerBuilder::new(Arc::clone(&partition_client), 0)
+    let mut stream = StreamConsumerBuilder::new(Arc::clone(&partition_client), StartOffset::At(0))
         .with_max_wait_ms(50)
         .build();
-
-    let assert_ok =
-        |r: Result<Option<<StreamConsumer as Stream>::Item>, tokio::time::error::Elapsed>| {
-            r.expect("no timeout")
-                .expect("some records")
-                .expect("no error")
-        };
 
     // Fetch first record
     assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
 
     // No further records
-    timeout(Duration::from_millis(200), stream.next())
-        .await
-        .expect_err("timeout");
+    assert_stream_pending(&mut stream).await;
 
     partition_client
         .produce(
@@ -71,9 +65,7 @@ async fn test_stream_consumer() {
     assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
 
     // No further records
-    timeout(Duration::from_millis(100), stream.next())
-        .await
-        .expect_err("timeout");
+    assert_stream_pending(&mut stream).await;
 }
 
 #[tokio::test]
@@ -92,7 +84,7 @@ async fn test_stream_consumer_offset_out_of_range() {
 
     let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
 
-    let mut stream = StreamConsumerBuilder::new(partition_client, 1).build();
+    let mut stream = StreamConsumerBuilder::new(partition_client, StartOffset::At(1)).build();
 
     let error = stream.next().await.expect("stream not empty").unwrap_err();
     assert_matches!(
@@ -102,4 +94,199 @@ async fn test_stream_consumer_offset_out_of_range() {
 
     // stream ends
     assert!(stream.next().await.is_none());
+}
+
+#[tokio::test]
+async fn test_stream_consumer_start_at_earliest() {
+    maybe_start_logging();
+
+    let connection = maybe_skip_kafka_integration!();
+    let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
+    let controller_client = client.controller_client().await.unwrap();
+
+    let topic = random_topic_name();
+    controller_client
+        .create_topic(&topic, 1, 1, 5_000)
+        .await
+        .unwrap();
+
+    let record_1 = record(b"x");
+    let record_2 = record(b"y");
+
+    let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
+    partition_client
+        .produce(vec![record_1.clone()], Compression::NoCompression)
+        .await
+        .unwrap();
+
+    let mut stream =
+        StreamConsumerBuilder::new(Arc::clone(&partition_client), StartOffset::Earliest)
+            .with_max_wait_ms(50)
+            .build();
+
+    // Fetch first record
+    let (record_and_offset, _) =
+        assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+    assert_eq!(record_and_offset.record, record_1);
+
+    // No further records
+    assert_stream_pending(&mut stream).await;
+
+    partition_client
+        .produce(vec![record_2.clone()], Compression::NoCompression)
+        .await
+        .unwrap();
+
+    // Get second record
+    let (record_and_offset, _) =
+        assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+    assert_eq!(record_and_offset.record, record_2);
+
+    // No further records
+    assert_stream_pending(&mut stream).await;
+}
+
+#[tokio::test]
+async fn test_stream_consumer_start_at_earliest_empty() {
+    maybe_start_logging();
+
+    let connection = maybe_skip_kafka_integration!();
+    let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
+    let controller_client = client.controller_client().await.unwrap();
+
+    let topic = random_topic_name();
+    controller_client
+        .create_topic(&topic, 1, 1, 5_000)
+        .await
+        .unwrap();
+
+    let record = record(b"x");
+
+    let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
+
+    let mut stream =
+        StreamConsumerBuilder::new(Arc::clone(&partition_client), StartOffset::Earliest)
+            .with_max_wait_ms(50)
+            .build();
+
+    // No records yet
+    assert_stream_pending(&mut stream).await;
+
+    partition_client
+        .produce(vec![record.clone()], Compression::NoCompression)
+        .await
+        .unwrap();
+
+    // Get second record
+    let (record_and_offset, _) =
+        assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+    assert_eq!(record_and_offset.record, record);
+
+    // No further records
+    assert_stream_pending(&mut stream).await;
+}
+
+#[tokio::test]
+async fn test_stream_consumer_start_at_latest() {
+    maybe_start_logging();
+
+    let connection = maybe_skip_kafka_integration!();
+    let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
+    let controller_client = client.controller_client().await.unwrap();
+
+    let topic = random_topic_name();
+    controller_client
+        .create_topic(&topic, 1, 1, 5_000)
+        .await
+        .unwrap();
+
+    let record_1 = record(b"x");
+    let record_2 = record(b"y");
+
+    let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
+    partition_client
+        .produce(vec![record_1.clone()], Compression::NoCompression)
+        .await
+        .unwrap();
+
+    let mut stream = StreamConsumerBuilder::new(Arc::clone(&partition_client), StartOffset::Latest)
+        .with_max_wait_ms(50)
+        .build();
+
+    // First record skipped
+    assert_stream_pending(&mut stream).await;
+
+    partition_client
+        .produce(vec![record_2.clone()], Compression::NoCompression)
+        .await
+        .unwrap();
+
+    // Get second record
+    let (record_and_offset, _) =
+        assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+    assert_eq!(record_and_offset.record, record_2);
+
+    // No further records
+    assert_stream_pending(&mut stream).await;
+}
+
+#[tokio::test]
+async fn test_stream_consumer_start_at_latest_empty() {
+    maybe_start_logging();
+
+    let connection = maybe_skip_kafka_integration!();
+    let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
+    let controller_client = client.controller_client().await.unwrap();
+
+    let topic = random_topic_name();
+    controller_client
+        .create_topic(&topic, 1, 1, 5_000)
+        .await
+        .unwrap();
+
+    let record = record(b"x");
+
+    let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
+
+    let mut stream = StreamConsumerBuilder::new(Arc::clone(&partition_client), StartOffset::Latest)
+        .with_max_wait_ms(50)
+        .build();
+
+    // No records yet
+    assert_stream_pending(&mut stream).await;
+
+    partition_client
+        .produce(vec![record.clone()], Compression::NoCompression)
+        .await
+        .unwrap();
+
+    // Get second record
+    let (record_and_offset, _) =
+        assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+    assert_eq!(record_and_offset.record, record);
+
+    // No further records
+    assert_stream_pending(&mut stream).await;
+}
+
+fn assert_ok(
+    r: Result<Option<<StreamConsumer as Stream>::Item>, tokio::time::error::Elapsed>,
+) -> (RecordAndOffset, i64) {
+    r.expect("no timeout")
+        .expect("some records")
+        .expect("no error")
+}
+
+/// Assert that given stream is pending.
+///
+/// This will will try to poll the stream for a bit to ensure that async IO has a chance to catch up.
+async fn assert_stream_pending<S>(stream: &mut S)
+where
+    S: Stream + Send + Unpin,
+    S::Item: std::fmt::Debug,
+{
+    tokio::select! {
+        e = stream.next() => panic!("stream is not pending, yielded: {e:?}"),
+        _ = tokio::time::sleep(Duration::from_millis(200)) => {},
+    };
 }

--- a/tests/produce_consume.rs
+++ b/tests/produce_consume.rs
@@ -138,7 +138,7 @@ async fn assert_produce_consume<F1, G1, F2, G2>(
     );
 
     let record_1 = {
-        let record = record();
+        let record = record(b"");
         match compression {
             Compression::NoCompression => record,
             #[allow(unreachable_patterns)]

--- a/tests/producer.rs
+++ b/tests/producer.rs
@@ -23,7 +23,7 @@ async fn test_batch_producer() {
         .await
         .unwrap();
 
-    let record = record();
+    let record = record(b"");
 
     let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
     let producer = BatchProducerBuilder::new(partition_client)

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -2,6 +2,7 @@ use parking_lot::Once;
 use rskafka::record::Record;
 use std::collections::BTreeMap;
 use time::OffsetDateTime;
+
 /// Get the testing Kafka connection string or return current scope.
 ///
 /// If `TEST_INTEGRATION` and `KAFKA_CONNECT` are set, return the Kafka connection URL to the
@@ -42,6 +43,29 @@ macro_rules! maybe_skip_kafka_integration {
             }
         }
     }};
+}
+
+/// Performs delete operation using.
+///
+/// This is skipped (via `return`) if the broker returns `NoVersionMatch`, except when the `TEST_DELETE_RECORDS`
+/// environment variable is set.
+///
+/// This is helpful because Redpanda does not support deletes yet, see
+/// <https://github.com/redpanda-data/redpanda/issues/1016> but we also don not want to skip these test unconditionally.
+#[macro_export]
+macro_rules! maybe_skip_delete {
+    ($partition_client:ident, $offset:expr) => {
+        match $partition_client.delete_records($offset, 1_000).await {
+            Ok(()) => {}
+            Err(rskafka::client::error::Error::Request(
+                rskafka::client::error::RequestError::NoVersionMatch { .. },
+            )) if std::env::var("TEST_DELETE_RECORDS").is_err() => {
+                println!("Skip test_delete_records");
+                return;
+            }
+            Err(e) => panic!("Cannot delete: {e}"),
+        }
+    };
 }
 
 /// Generated random topic name for testing.

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -49,9 +49,9 @@ pub fn random_topic_name() -> String {
     format!("test_topic_{}", uuid::Uuid::new_v4())
 }
 
-pub fn record() -> Record {
+pub fn record(key: &[u8]) -> Record {
     Record {
-        key: Some(b"".to_vec()),
+        key: Some(key.to_vec()),
         value: Some(b"hello kafka".to_vec()),
         headers: BTreeMap::from([("foo".to_owned(), b"bar".to_vec())]),
         timestamp: now(),


### PR DESCRIPTION
This is required to provide a race-free way to start at the earliest or
latest offset, because fetching the offset and then creating a stream
might fail because in the meantime the Kafka retention policy might
already have removed the offsets in question.
