### PR TITLE
fix: disallow now_or_never  (and async `read`)

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,4 @@
 disallowed-methods = [
     { path = "tokio::io::AsyncWriteExt::write", reason = "Use `write_all`, because you likely forgot to use the IO amount. Also see `unused_io_amount` clippy lint." },
+    { path = "futures_util::future::future::FutureExt::now_or_never", reason = "Tokio might preempt tasks at any time, see https://tokio.rs/blog/2020-04-preemption" }
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,5 @@
 disallowed-methods = [
+    { path = "tokio::io::AsyncReadExt::read", reason = "Use `read_exact`, because you likely forgot to use the IO amount. Also see `unused_io_amount` clippy lint." },
     { path = "tokio::io::AsyncWriteExt::write", reason = "Use `write_all`, because you likely forgot to use the IO amount. Also see `unused_io_amount` clippy lint." },
     { path = "futures_util::future::future::FutureExt::now_or_never", reason = "Tokio might preempt tasks at any time, see https://tokio.rs/blog/2020-04-preemption" }
 ]

--- a/src/client/consumer.rs
+++ b/src/client/consumer.rs
@@ -450,12 +450,20 @@ mod tests {
         assert_eq!(high_watermark, 5);
 
         let (record_and_offset, high_watermark) =
-            stream.next().now_or_never().unwrap().unwrap().unwrap();
+            tokio::time::timeout(Duration::from_millis(1), stream.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
         assert_eq!(record_and_offset.offset, 4);
         assert_eq!(high_watermark, 5);
 
         let (record_and_offset, high_watermark) =
-            stream.next().now_or_never().unwrap().unwrap().unwrap();
+            tokio::time::timeout(Duration::from_millis(1), stream.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
         assert_eq!(record_and_offset.offset, 5);
         assert_eq!(high_watermark, 5);
 


### PR DESCRIPTION
Tokio might preempt tasks at any point so `now_or_never` might return
`None`. See https://tokio.rs/blog/2020-04-preemption

We could try to workaround this by using data structures from `futures`
instead of `tokio` which to not hook into the tokio cooperative
scheduling. However this has certain drawbacks

- The cooperative scheduling in tokio is actually not that bad, so we
  should rather work with it instead of against it.
- The assumption that `futures` data structures don't participate in
  cooperative scheduling is only because currently they cannot interact
  with the runtime in any way. This might change when Rust's async
  ecosystem evolves so it kinda seems like a non-future-proof
  workaround.

Fixes #102.

While I'm on it I also disallowed async `read` because it has the same issue as the `write` counterpart that we've already run into.