### PR TITLE
fix: ignore `InvalidReplicationFactor`

### DIFF
--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -365,6 +365,7 @@ where
             match error {
                 Error::Request(RequestError::Poisoned(_) | RequestError::IO(_))
                 | Error::Connection(_) => broker_cache.invalidate().await,
+                Error::ServerError(ProtocolError::InvalidReplicationFactor, _) => {}
                 Error::ServerError(ProtocolError::LeaderNotAvailable, _) => {}
                 Error::ServerError(ProtocolError::OffsetNotAvailable, _) => {}
                 Error::ServerError(ProtocolError::NotLeaderOrFollower, _) => {


### PR DESCRIPTION
This keeps consumer streams from dying when the Kafka cluster is in flux
(e.g. when Strimzi restarts brokers).

Fixes #84.
