### PR TITLE
fix: `peek` after broadcast

### DIFF
--- a/src/client/producer/broadcast.rs
+++ b/src/client/producer/broadcast.rs
@@ -9,18 +9,27 @@ use tracing::warn;
 ///
 /// - Receivers can be created with `BroadcastOnce::receiver`
 /// - The value can be produced with `BroadcastOnce::broadcast`
-pub struct BroadcastOnce<T: Clone> {
+pub struct BroadcastOnce<T>
+where
+    T: Clone + Send + Sync,
+{
     receiver: futures::future::Shared<ReceiveFut<T>>,
     sender: oneshot::Sender<T>,
 }
 
-impl<T: Clone> std::fmt::Debug for BroadcastOnce<T> {
+impl<T> std::fmt::Debug for BroadcastOnce<T>
+where
+    T: Clone + Send + Sync,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "ResultSlot")
     }
 }
 
-impl<T: Clone> Default for BroadcastOnce<T> {
+impl<T> Default for BroadcastOnce<T>
+where
+    T: Clone + Send + Sync,
+{
     fn default() -> Self {
         let (sender, receiver) = oneshot::channel();
         Self {
@@ -30,16 +39,30 @@ impl<T: Clone> Default for BroadcastOnce<T> {
     }
 }
 
-impl<T: Clone> BroadcastOnce<T> {
+impl<T> BroadcastOnce<T>
+where
+    T: Clone + Send + Sync,
+{
     /// Returns a [`Future`] that completes when [`BroadcastOnce::broadcast`] is called
     pub fn receive(&self) -> futures::future::Shared<impl Future<Output = T>> {
         self.receiver.clone()
     }
 
-    /// Broadcast a value to all [`BroadcastOnce::receive`] handles
-    pub fn broadcast(self, r: T) {
+    /// Broadcast a value to all [`BroadcastOnce::receive`] handles.
+    ///
+    /// You may [`peek`](futures::future::Shared::peek) the [`receive`](Self::receive) future instantly after calling
+    /// this method and get a result back.
+    pub async fn broadcast(self, r: T) {
         // Don't care if no receivers
-        let _ = self.sender.send(r);
+        {
+            self.sender.send(r).ok();
+        }
+
+        // We need to poll the result slot here to make the result available via `peek`, otherwise the next thread in
+        // this critical section will flush the producer a 2nd time. We are using an ordinary `.await` call here instead
+        // of `now_or_never` because tokio might preempt us (or to be precise: might preempt polling from the result
+        // slot).
+        self.receiver.await;
     }
 }
 
@@ -77,19 +100,19 @@ mod tests {
     async fn test_broadcast_once() {
         // Test no receiver
         let broadcast: BroadcastOnce<usize> = Default::default();
-        broadcast.broadcast(1);
+        broadcast.broadcast(1).await;
 
         // Test simple receiver
         let broadcast: BroadcastOnce<usize> = Default::default();
         let receiver = broadcast.receive();
-        broadcast.broadcast(2);
+        broadcast.broadcast(2).await;
         assert_eq!(receiver.await, 2);
 
         // Test multiple receiver
         let broadcast: BroadcastOnce<usize> = Default::default();
         let r1 = broadcast.receive();
         let r2 = broadcast.receive();
-        broadcast.broadcast(4);
+        broadcast.broadcast(4).await;
         assert_eq!(r1.await, 4);
         assert_eq!(r2.await, 4);
 
@@ -98,8 +121,18 @@ mod tests {
         let mut r1 = broadcast.receive();
         let r2 = broadcast.receive();
         assert_is_pending(&mut r1).await;
-        broadcast.broadcast(5);
+        broadcast.broadcast(5).await;
         assert_eq!(r2.await, 5);
+    }
+
+    #[tokio::test]
+    async fn test_peek() {
+        let broadcast: BroadcastOnce<usize> = Default::default();
+        let r1 = broadcast.receive();
+        let r2 = broadcast.receive();
+        broadcast.broadcast(1).await;
+        assert_eq!(r1.peek().unwrap(), &1);
+        assert_eq!(r2.peek().unwrap(), &1);
     }
 
     async fn assert_is_pending<F, T>(f: &mut F)


### PR DESCRIPTION
`BroadcastOne::receive().peek()` did only return `Some(...)` if the
receiver side was actually `await`ed at least once. Thie was already
discovered and solved here:

https://github.com/influxdata/rskafka/blob/3af1939fd47f8680d40074dc3fd2e2a4a0da6b8c/src/client/producer.rs#L442-L445
https://github.com/influxdata/influxdb_iox/pull/3873/files
However in case of flushes due to "no capacity" we didn't `await`

https://github.com/influxdata/rskafka/blob/3af1939fd47f8680d40074dc3fd2e2a4a0da6b8c/src/client/producer.rs#L397

and then `peek`ed

https://github.com/influxdata/rskafka/blob/3af1939fd47f8680d40074dc3fd2e2a4a0da6b8c/src/client/producer.rs#L433

determined that we probably didn't flush the aggregator and then flushed
it again. This resulted in an empty flush and the tags that we tried to
de-aggregate didn't work (because the deaggregator that was now in the
result slot was not the one that matched our actual tag).

Instead of blindly adding more `await` calls, this PR makes the
`BroadcastOne` API a bit saver by `await`ing in `BroadcastOne::broadcast`,
so we now guarantee that `peek` always works after broadcasting.
