### PR TITLE
fix: make `Messenger::request` cancellation-safe

### DIFF
--- a/fuzz/fuzz_targets/protocol_reader.rs
+++ b/fuzz/fuzz_targets/protocol_reader.rs
@@ -34,9 +34,9 @@ fn driver(data: &[u8]) -> Result<(), Error> {
     match api_key {
         ApiKey::ApiVersions => send_recv(
             ApiVersionsRequest {
-                client_software_name: CompactString(String::new()),
-                client_software_version: CompactString(String::new()),
-                tagged_fields: TaggedFields::default(),
+                client_software_name: Some(CompactString(String::new())),
+                client_software_version: Some(CompactString(String::new())),
+                tagged_fields: Some(TaggedFields::default()),
             },
             cursor,
             api_key,

--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -298,8 +298,8 @@ where
             request_api_key: R::API_KEY,
             request_api_version: body_api_version,
             correlation_id: Int32(correlation_id),
-            client_id: NullableString(None),
-            tagged_fields: TaggedFields::default(),
+            client_id: Some(NullableString(None)),
+            tagged_fields: Some(TaggedFields::default()),
         };
         let header_version = if use_tagged_fields_in_request {
             ApiVersion(Int16(2))

--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -388,9 +388,11 @@ where
             )]));
 
             let body = ApiVersionsRequest {
-                client_software_name: CompactString(String::from(env!("CARGO_PKG_NAME"))),
-                client_software_version: CompactString(String::from(env!("CARGO_PKG_VERSION"))),
-                tagged_fields: TaggedFields::default(),
+                client_software_name: Some(CompactString(String::from(env!("CARGO_PKG_NAME")))),
+                client_software_version: Some(CompactString(String::from(env!(
+                    "CARGO_PKG_VERSION"
+                )))),
+                tagged_fields: Some(TaggedFields::default()),
             };
 
             match self.request(body).await {
@@ -923,9 +925,9 @@ mod tests {
 
         let actual = messenger
             .request(ApiVersionsRequest {
-                client_software_name: CompactString(String::new()),
-                client_software_version: CompactString(String::new()),
-                tagged_fields: TaggedFields::default(),
+                client_software_name: Some(CompactString(String::new())),
+                client_software_version: Some(CompactString(String::new())),
+                tagged_fields: Some(TaggedFields::default()),
             })
             .await
             .unwrap();
@@ -1018,9 +1020,9 @@ mod tests {
         let task_to_cancel = (async {
             messenger
                 .request(ApiVersionsRequest {
-                    client_software_name: CompactString(String::from("foo")),
-                    client_software_version: CompactString(String::from("bar")),
-                    tagged_fields: TaggedFields::default(),
+                    client_software_name: Some(CompactString(String::from("foo"))),
+                    client_software_version: Some(CompactString(String::from("bar"))),
+                    tagged_fields: Some(TaggedFields::default()),
                 })
                 .await
                 .unwrap();
@@ -1046,9 +1048,9 @@ mod tests {
         tokio::time::timeout(Duration::from_millis(100), async {
             messenger
                 .request(ApiVersionsRequest {
-                    client_software_name: CompactString(String::from("foo")),
-                    client_software_version: CompactString(String::from("bar")),
-                    tagged_fields: TaggedFields::default(),
+                    client_software_name: Some(CompactString(String::from("foo"))),
+                    client_software_version: Some(CompactString(String::from("bar"))),
+                    tagged_fields: Some(TaggedFields::default()),
                 })
                 .await
                 .unwrap();

--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -944,7 +944,7 @@ mod tests {
         let network_pause = Arc::new(Barrier::new(2));
         let network_pause_captured = Arc::clone(&network_pause);
         let handle_network = tokio::spawn(async move {
-            // Need to split both directions into read and write halfs so we can run full-deplux in two loops. Otherwise
+            // Need to split both directions into read and write halfs so we can run full-duplex in two loops. Otherwise
             // the test might deadlock even though the code is just fine (TCP is full-duplex).
             let (mut rx_middle_read, mut rx_middle_write) = tokio::io::split(rx_middle);
             let (mut tx_middle_read, mut tx_middle_write) = tokio::io::split(tx_middle);

--- a/src/protocol/primitives.rs
+++ b/src/protocol/primitives.rs
@@ -360,7 +360,7 @@ where
 }
 
 /// Represents a string whose length is expressed as a variable-length integer rather than a fixed 2-byte length.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct CompactString(pub String);
 

--- a/src/protocol/primitives.rs
+++ b/src/protocol/primitives.rs
@@ -281,7 +281,7 @@ where
 ///
 /// For non-null strings, first the length N is given as an INT16. Then N bytes follow which are the UTF-8 encoding of
 /// the character sequence. A null value is encoded with length of -1 and there are no following bytes.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct NullableString(pub Option<String>);
 


### PR DESCRIPTION
This avoids that we write partial messages to the underlying TCP/TLS
connection and mess up message framing. This will nearly always lead to
broker-side errors and the broker closes the connection.

Fixes #103.
