### PR TITLE
fix: TLS feature flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,7 @@ jobs:
       - cache_restore
       - run:
           name: Cargo build
-          command: cargo build --no-default-features
+          command: cargo build --no-default-features --all-targets
       - cache_save
 
   # Builds RSKafka w/ all features.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -620,7 +620,7 @@ mod tests {
 
         async fn connect(
             &self,
-            _tls_config: Option<Arc<rustls::ClientConfig>>,
+            _tls_config: TlsConfig,
             _socks5_proxy: Option<String>,
             _max_message_size: usize,
         ) -> Result<Arc<Self::R>> {

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -73,6 +73,7 @@ async fn test_topic_crud() {
 // Disabled as currently no TLS integration tests
 #[ignore]
 #[tokio::test]
+#[cfg(feature = "transport-tls")]
 async fn test_tls() {
     maybe_start_logging();
 


### PR DESCRIPTION
Some parts of the code were referencing types behind feature flags, and CI wasn't catching it - this PR corrects both.

---

* fix: missing TLS feature gates (1c0eb13)

      Adds missing cfg(tls) annotations to code blocks that require it, allowing
      cargo check --all-targets to pass.

* ci: check all targets with no features (04f6863)

      Adds --all-targets to the "no default features" build, which causes it to
      validate the flags used in #[cfg(test)] gated blocks too.