### PR TITLE
feat: split produce batches for MESSAGE_TOO_LARGE errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ let partition_client = client
 // produce some data
 let record = Record {
     key: None,
-    value: Some(b"hello kafka".to_vec()),
+    value: Some(Arc::new(b"hello kafka".to_vec())),
     headers: BTreeMap::from([
         ("foo".to_owned(), b"bar".to_vec()),
     ]),

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ use rskafka::{
     record::Record,
 };
 use time::OffsetDateTime;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 // setup client
 let connection = "localhost:9093".to_owned();
@@ -71,7 +71,7 @@ let record = Record {
     ]),
     timestamp: OffsetDateTime::now_utc(),
 };
-partition_client.produce(vec![record], Compression::default()).await.unwrap();
+partition_client.produce(&[record], Compression::default()).await.unwrap();
 
 // consume data
 let (records, high_watermark) = partition_client

--- a/benches/write_throughput.rs
+++ b/benches/write_throughput.rs
@@ -82,7 +82,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
                     for _ in 0..iters {
                         client
-                            .produce(vec![record.clone()], Compression::NoCompression)
+                            .produce(&[record.clone()], Compression::NoCompression)
                             .await
                             .unwrap();
                     }

--- a/benches/write_throughput.rs
+++ b/benches/write_throughput.rs
@@ -72,8 +72,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 async move {
                     let client = setup_rskafka(connection).await;
                     let record = Record {
-                        key: Some(key),
-                        value: Some(value),
+                        key: Some(Arc::new(key)),
+                        value: Some(Arc::new(value)),
                         headers: BTreeMap::default(),
                         timestamp: OffsetDateTime::now_utc(),
                     };
@@ -139,8 +139,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 async move {
                     let client = setup_rskafka(connection).await;
                     let record = Record {
-                        key: Some(key),
-                        value: Some(value),
+                        key: Some(Arc::new(key)),
+                        value: Some(Arc::new(value)),
                         headers: BTreeMap::default(),
                         timestamp: OffsetDateTime::now_utc(),
                     };

--- a/src/client/consumer.rs
+++ b/src/client/consumer.rs
@@ -498,8 +498,8 @@ mod tests {
     #[tokio::test]
     async fn test_consumer() {
         let record = Record {
-            key: Some(vec![0; 4]),
-            value: Some(vec![0; 6]),
+            key: Some(Arc::new(vec![0; 4])),
+            value: Some(Arc::new(vec![0; 6])),
             headers: Default::default(),
             timestamp: OffsetDateTime::now_utc(),
         };
@@ -565,8 +565,8 @@ mod tests {
     #[tokio::test]
     async fn test_consumer_timeout() {
         let record = Record {
-            key: Some(vec![0; 4]),
-            value: Some(vec![0; 6]),
+            key: Some(Arc::new(vec![0; 4])),
+            value: Some(Arc::new(vec![0; 6])),
             headers: Default::default(),
             timestamp: OffsetDateTime::now_utc(),
         };
@@ -650,8 +650,8 @@ mod tests {
     #[tokio::test]
     async fn test_consumer_earliest() {
         let record = Record {
-            key: Some(vec![0; 4]),
-            value: Some(vec![0; 6]),
+            key: Some(Arc::new(vec![0; 4])),
+            value: Some(Arc::new(vec![0; 6])),
             headers: Default::default(),
             timestamp: OffsetDateTime::now_utc(),
         };
@@ -694,8 +694,8 @@ mod tests {
     #[tokio::test]
     async fn test_consumer_latest() {
         let record = Record {
-            key: Some(vec![0; 4]),
-            value: Some(vec![0; 6]),
+            key: Some(Arc::new(vec![0; 4])),
+            value: Some(Arc::new(vec![0; 6])),
             headers: Default::default(),
             timestamp: OffsetDateTime::now_utc(),
         };

--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -105,9 +105,9 @@ impl PartitionClient {
     }
 
     /// Produce a batch of records to the partition
-    pub async fn produce(
-        &self,
-        records: Vec<Record>,
+    pub async fn produce<'a>(
+        &'a self,
+        records: &'a [Record],
         compression: Compression,
     ) -> Result<Vec<i64>> {
         // skip request entirely if `records` is empty
@@ -395,7 +395,7 @@ where
 fn build_produce_request(
     partition: i32,
     topic: &str,
-    records: Vec<Record>,
+    records: &[Record],
     compression: Compression,
 ) -> ProduceRequest {
     let n = records.len() as i32;
@@ -419,6 +419,7 @@ fn build_produce_request(
                 offset_delta: offset_delta as i32,
                 headers: record
                     .headers
+                    .clone()
                     .into_iter()
                     .map(|(key, value)| RecordHeader { key, value })
                     .collect(),

--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -407,7 +407,7 @@ fn build_produce_request(
     let mut max_timestamp = first_timestamp;
 
     let records = records
-        .into_iter()
+        .iter()
         .enumerate()
         .map(|(offset_delta, record)| {
             max_timestamp = max_timestamp.max(record.timestamp);
@@ -601,8 +601,7 @@ fn extract_records(
                                 .headers
                                 .into_iter()
                                 .map(|header| (header.key, header.value))
-                                .collect::<BTreeMap<_, _>>()
-                                .into(),
+                                .collect::<BTreeMap<_, _>>(),
                             timestamp,
                         },
                         offset,

--- a/src/client/producer.rs
+++ b/src/client/producer.rs
@@ -73,7 +73,7 @@
 //! // produce data
 //! let record = Record {
 //!     key: None,
-//!     value: Some(b"hello kafka".to_vec()),
+//!     value: Some(Arc::new(b"hello kafka".to_vec())),
 //!     headers: BTreeMap::from([
 //!         ("foo".to_owned(), b"bar".to_vec()),
 //!     ]),
@@ -146,7 +146,7 @@
 //!         let records = vec![
 //!             Record {
 //!                 key: None,
-//!                 value: Some(data),
+//!                 value: Some(Arc::new(data)),
 //!                 headers: BTreeMap::from([
 //!                     ("foo".to_owned(), b"bar".to_vec()),
 //!                 ]),
@@ -563,8 +563,8 @@ mod tests {
 
     fn record() -> Record {
         Record {
-            key: Some(vec![0; 4]),
-            value: Some(vec![0; 6]),
+            key: Some(Arc::new(vec![0; 4])),
+            value: Some(Arc::new(vec![0; 6])),
             headers: Default::default(),
             timestamp: OffsetDateTime::from_unix_timestamp(320).unwrap(),
         }

--- a/src/client/producer/aggregator.rs
+++ b/src/client/producer/aggregator.rs
@@ -143,20 +143,22 @@ impl StatusDeaggregator for RecordAggregatorStatusDeaggregator {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use time::OffsetDateTime;
 
     #[test]
     fn test_record_aggregator() {
         let r1 = Record {
-            key: Some(vec![0; 45]),
-            value: Some(vec![0; 2]),
+            key: Some(Arc::new(vec![0; 45])),
+            value: Some(Arc::new(vec![0; 2])),
             headers: Default::default(),
             timestamp: OffsetDateTime::from_unix_timestamp(20).unwrap(),
         };
 
         let r2 = Record {
-            value: Some(vec![0; 34]),
+            value: Some(Arc::new(vec![0; 34])),
             ..r1.clone()
         };
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,12 +1,12 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 use time::OffsetDateTime;
 
 /// High-level record.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Record {
-    pub key: Option<Vec<u8>>,
-    pub value: Option<Vec<u8>>,
+    pub key: Option<Arc<Vec<u8>>>,
+    pub value: Option<Arc<Vec<u8>>>,
     pub headers: BTreeMap<String, Vec<u8>>,
     pub timestamp: OffsetDateTime,
 }
@@ -38,8 +38,8 @@ mod tests {
     #[test]
     fn test_approximate_size() {
         let record = Record {
-            key: Some(vec![0; 23]),
-            value: Some(vec![0; 45]),
+            key: Some(Arc::new(vec![0; 23])),
+            value: Some(Arc::new(vec![0; 45])),
             headers: vec![("a".to_string(), vec![0; 5]), ("b".to_string(), vec![0; 7])]
                 .into_iter()
                 .collect(),

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -152,7 +152,7 @@ async fn test_produce_empty() {
 
     let partition_client = client.partition_client(&topic_name, 1).await.unwrap();
     partition_client
-        .produce(vec![], Compression::NoCompression)
+        .produce(&[], Compression::NoCompression)
         .await
         .unwrap();
 }
@@ -199,7 +199,7 @@ async fn test_consume_offset_out_of_range() {
     let partition_client = client.partition_client(&topic_name, 1).await.unwrap();
     let record = record(b"");
     let offsets = partition_client
-        .produce(vec![record], Compression::NoCompression)
+        .produce(&[record], Compression::NoCompression)
         .await
         .unwrap();
     let offset = offsets[0];
@@ -257,13 +257,13 @@ async fn test_get_offset() {
         ..record_early.clone()
     };
     let offsets = partition_client
-        .produce(vec![record_late.clone()], Compression::NoCompression)
+        .produce(&[record_late.clone()], Compression::NoCompression)
         .await
         .unwrap();
     assert_eq!(offsets[0], 0);
 
     let offsets = partition_client
-        .produce(vec![record_early.clone()], Compression::NoCompression)
+        .produce(&[record_early.clone()], Compression::NoCompression)
         .await
         .unwrap();
     assert_eq!(offsets.len(), 1);
@@ -304,15 +304,15 @@ async fn test_produce_consume_size_cutoff() {
 
     // produce in spearate request so we have three record batches
     partition_client
-        .produce(vec![record_1.clone()], Compression::NoCompression)
+        .produce(&[record_1.clone()], Compression::NoCompression)
         .await
         .unwrap();
     partition_client
-        .produce(vec![record_2.clone()], Compression::NoCompression)
+        .produce(&[record_2.clone()], Compression::NoCompression)
         .await
         .unwrap();
     partition_client
-        .produce(vec![record_3.clone()], Compression::NoCompression)
+        .produce(&[record_3.clone()], Compression::NoCompression)
         .await
         .unwrap();
 
@@ -377,7 +377,7 @@ async fn test_consume_midbatch() {
 
     let offsets = partition_client
         .produce(
-            vec![record_1.clone(), record_2.clone()],
+            &[record_1.clone(), record_2.clone()],
             Compression::NoCompression,
         )
         .await
@@ -426,14 +426,14 @@ async fn test_delete_records() {
     let record_4 = record(b"z");
 
     let offsets = partition_client
-        .produce(vec![record_1.clone()], Compression::NoCompression)
+        .produce(&[record_1.clone()], Compression::NoCompression)
         .await
         .unwrap();
     let offset_1 = offsets[0];
 
     let offsets = partition_client
         .produce(
-            vec![record_2.clone(), record_3.clone()],
+            &[record_2.clone(), record_3.clone()],
             Compression::NoCompression,
         )
         .await
@@ -442,7 +442,7 @@ async fn test_delete_records() {
     let offset_3 = offsets[1];
 
     let offsets = partition_client
-        .produce(vec![record_4.clone()], Compression::NoCompression)
+        .produce(&[record_4.clone()], Compression::NoCompression)
         .await
         .unwrap();
     let offset_4 = offsets[0];

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -504,8 +504,8 @@ async fn test_delete_records() {
 
 pub fn large_record() -> Record {
     Record {
-        key: Some(b"".to_vec()),
-        value: Some(vec![b'x'; 1024]),
+        key: Some(Arc::new(b"".to_vec())),
+        value: Some(Arc::new(vec![b'x'; 1024])),
         headers: BTreeMap::from([("foo".to_owned(), b"bar".to_vec())]),
         timestamp: now(),
     }

--- a/tests/consumer.rs
+++ b/tests/consumer.rs
@@ -36,7 +36,7 @@ async fn test_stream_consumer_start_at_0() {
 
     let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
     partition_client
-        .produce(vec![record.clone()], Compression::NoCompression)
+        .produce(&[record.clone()], Compression::NoCompression)
         .await
         .unwrap();
 
@@ -52,7 +52,7 @@ async fn test_stream_consumer_start_at_0() {
 
     partition_client
         .produce(
-            vec![record.clone(), record.clone()],
+            &[record.clone(), record.clone()],
             Compression::NoCompression,
         )
         .await
@@ -88,7 +88,7 @@ async fn test_stream_consumer_start_at_1() {
     let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
     partition_client
         .produce(
-            vec![record_1.clone(), record_2.clone()],
+            &[record_1.clone(), record_2.clone()],
             Compression::NoCompression,
         )
         .await
@@ -154,7 +154,7 @@ async fn test_stream_consumer_start_at_earliest() {
 
     let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
     partition_client
-        .produce(vec![record_1.clone()], Compression::NoCompression)
+        .produce(&[record_1.clone()], Compression::NoCompression)
         .await
         .unwrap();
 
@@ -172,7 +172,7 @@ async fn test_stream_consumer_start_at_earliest() {
     assert_stream_pending(&mut stream).await;
 
     partition_client
-        .produce(vec![record_2.clone()], Compression::NoCompression)
+        .produce(&[record_2.clone()], Compression::NoCompression)
         .await
         .unwrap();
 
@@ -212,7 +212,7 @@ async fn test_stream_consumer_start_at_earliest_empty() {
     assert_stream_pending(&mut stream).await;
 
     partition_client
-        .produce(vec![record.clone()], Compression::NoCompression)
+        .produce(&[record.clone()], Compression::NoCompression)
         .await
         .unwrap();
 
@@ -245,7 +245,7 @@ async fn test_stream_consumer_start_at_earliest_after_deletion() {
     let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
     partition_client
         .produce(
-            vec![record_1.clone(), record_2.clone()],
+            &[record_1.clone(), record_2.clone()],
             Compression::NoCompression,
         )
         .await
@@ -286,7 +286,7 @@ async fn test_stream_consumer_start_at_latest() {
 
     let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
     partition_client
-        .produce(vec![record_1.clone()], Compression::NoCompression)
+        .produce(&[record_1.clone()], Compression::NoCompression)
         .await
         .unwrap();
 
@@ -298,7 +298,7 @@ async fn test_stream_consumer_start_at_latest() {
     assert_stream_pending(&mut stream).await;
 
     partition_client
-        .produce(vec![record_2.clone()], Compression::NoCompression)
+        .produce(&[record_2.clone()], Compression::NoCompression)
         .await
         .unwrap();
 
@@ -337,7 +337,7 @@ async fn test_stream_consumer_start_at_latest_empty() {
     assert_stream_pending(&mut stream).await;
 
     partition_client
-        .produce(vec![record.clone()], Compression::NoCompression)
+        .produce(&[record.clone()], Compression::NoCompression)
         .await
         .unwrap();
 

--- a/tests/produce_consume.rs
+++ b/tests/produce_consume.rs
@@ -250,7 +250,7 @@ async fn produce_rskafka(
     compression: Compression,
 ) -> Vec<i64> {
     partition_client
-        .produce(records, compression)
+        .produce(&records, compression)
         .await
         .unwrap()
 }

--- a/tests/produce_consume.rs
+++ b/tests/produce_consume.rs
@@ -170,19 +170,19 @@ async fn assert_produce_consume<F1, G1, F2, G2>(
                 // add a bit more data to encourage rdkafka to actually use compression, otherwise the compressed data
                 // is larger than the uncompressed version and rdkafka will not use compression at all
                 Record {
-                    key: Some(vec![b'x'; 100]),
+                    key: Some(Arc::new(vec![b'x'; 100])),
                     ..record
                 }
             }
         }
     };
     let record_2 = Record {
-        value: Some(b"some value".to_vec()),
+        value: Some(Arc::new(b"some value".to_vec())),
         timestamp: now(),
         ..record_1.clone()
     };
     let record_3 = Record {
-        value: Some(b"more value".to_vec()),
+        value: Some(Arc::new(b"more value".to_vec())),
         timestamp: now(),
         ..record_1.clone()
     };

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -1,6 +1,6 @@
 use parking_lot::Once;
 use rskafka::record::Record;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 use time::OffsetDateTime;
 
 /// Get the testing Kafka connection string or return current scope.
@@ -75,8 +75,8 @@ pub fn random_topic_name() -> String {
 
 pub fn record(key: &[u8]) -> Record {
     Record {
-        key: Some(key.to_vec()),
-        value: Some(b"hello kafka".to_vec()),
+        key: Some(Arc::new(key.to_vec())),
+        value: Some(Arc::new(b"hello kafka".to_vec())),
         headers: BTreeMap::from([("foo".to_owned(), b"bar".to_vec())]),
         timestamp: now(),
     }


### PR DESCRIPTION
This PR allows a batched `produce()` call to try and automatically handle `MESSAGE_TOO_LARGE` errors by splitting the aggregated batch in two, and submitting each half individually. 

While most incidents of this error are due to bad configuration, it can occur even with correctly tuned message sizes due to the aggregator using the approximated record sizes. A `WARN` log event is emitted each time this automatic splitting is needed to surface any potential misconfiguration to the operator.

This automatic splitting has pros, and cons:

* Pro: client doesn't have to care about batch sizing approximation going wrong
* Pro: the produce caller retains the original `Record`, rather than giving up ownership - this makes resubmitting / error handling possible for the caller.
* Con: extra pointer indirection & ref counting (negligent in the grand scheme of things)
* Con: partial writes can be infrequently triggered in the `MESSAGE_TOO_LARGE` path, as are spurious produce errors

---

* refactor: wrap record key/value in Arc (43b776e)

      Allows "copies" of the key/value bytes to be held for produce request retries
      without having to actually copy the underlying buffer, at the minor cost of
      extra pointer indirection.

* refactor: lend Records to produce() calls (39bac2d)

      Changes the ProducerClient::produce() call to take a slice of Records rather
      than a Vec, allowing the caller to retain the original buffer and easily
      provide a subset slice of the original buffer as needed.

* refactor: let MockClient return response sequences (9b7ecf1)

      This change affects test code only, changing the MockClient to return a 
      sequence of configured errors, rather than the same error all the time.

      As an example, this can be used to construct a test that observes an error,
      followed by a different error, followed by a success - the previous mock was
      restricted to always returning the same response.

* feat: split produce batch for MESSAGE_TOO_LARGE (99e15b3)

      Aggregating the records for produce requests is approximate, and as such 
      sometimes may result in a batch larger than the configured maximum - if the
      size of the batch exceeds the broker's maximum allowed message size
      (message.max.bytes) a MESSAGE_TOO_LARGE error is returned.

      At this point and prior to this commit, the whole batch was dropped and the
      caller has to retry, hoping the retries do not batch into a too-large batch
      once again. After this commit, exactly one attempt is made to
      automatically/internally split the batch in half and attempt to concurrently
      produce each half transparently to the caller. A message is logged at WARN to
      help the user identify and tune this config to avoid this.

      The two downsides of this are:

         * Unpredictable latency if a batch needs splitting and re-submitting
         * A partial write may occur (writing one half succeeds, other fails)

      These downsides are offset by the fact the MESSAGE_TOO_LARGE should be a rare
      event, making the latency hit equally rare. Succeeding in producing one batch
      but not the other is even rarer still, but does result in an error being
      returned to the client even though have the records were successfully
      produced. The caller had no control over which writes were in which aggregated
      batches anyway, so has no expectation of two writes succeeding/failing
      together (atomicity).