### PR TITLE
chore: remove obsolete semantic config file

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,5 +1,0 @@
----
-# docs: https://github.com/probot/semantic-pull-requests#configuration
-# Always validate the PR title AND all the commits
-titleAndCommits: true
-allowMergeCommits: true


### PR DESCRIPTION
The external bot was replaced by a GitHub action in #127.
