### PR TITLE
ci: add code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,15 @@ commands:
             sudo apt-get update
             sudo apt-get install -y openjdk-11-jre zlib1g-dev
 
+  install_cargo-llvm-cov:
+    description: Install cargo-llvm-cov for code coverage
+    steps:
+      - run:
+          name: Install cargo-llvm-cov for code coverage
+          command: |
+            rustup component add llvm-tools-preview
+            cargo install cargo-llvm-cov
+
 jobs:
   fmt:
     docker:
@@ -205,12 +214,15 @@ jobs:
       - rust_components
       - cache_restore
       - install_packages
+      - install_cargo-llvm-cov
       - run:
           name: Cargo test
-          command: cargo test --all-features --all-targets
+          command: cargo llvm-cov --all-features --all-targets --html
       - cache_save
       - store_artifacts:
           path: proptest-regressions
+      - store_artifacts:
+          path: target/llvm-cov
 
   test-kafka:
     # setup multiple docker images (see https://circleci.com/docs/2.0/configuration-reference/#docker)


### PR DESCRIPTION
Closes [#137](https://github.com/influxdata/rskafka/issues/137) 

Add code coverage for CI in the redpanda test. The code coverage report(html) will be stored in artifacts.

- [X] I've read the contributing section of the project [CONTRIBUTING.md](https://github.com/influxdata/rskafka/blob/main/CONTRIBUTING.md).
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
