### PR TITLE
fix: remove potentially buggy Redpanda quirk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
     # setup multiple docker images (see https://circleci.com/docs/2.0/configuration-reference/#docker)
     docker:
       - image: quay.io/influxdb/rust:ci
-      - image: vectorized/redpanda:v21.11.2
+      - image: vectorized/redpanda:v22.1.4
         name: redpanda-0
         command:
           - redpanda
@@ -152,7 +152,7 @@ jobs:
           - --check=false
           - --kafka-addr redpanda-0:9092
           - --rpc-addr redpanda-0:33145
-      - image: vectorized/redpanda:v21.11.2
+      - image: vectorized/redpanda:v22.1.4
         name: redpanda-1
         command:
           - redpanda
@@ -166,7 +166,7 @@ jobs:
           - --kafka-addr redpanda-1:9092
           - --rpc-addr redpanda-1:33145
           - --seeds redpanda-0:33145
-      - image: vectorized/redpanda:v21.11.2
+      - image: vectorized/redpanda:v22.1.4
         name: redpanda-2
         command:
           - redpanda

--- a/docker-compose-redpanda.yml
+++ b/docker-compose-redpanda.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   redpanda-0:
-    image: vectorized/redpanda:v21.11.2
+    image: vectorized/redpanda:v22.1.4
     container_name: redpanda-0
     ports:
       - '9010:9010'
@@ -19,7 +19,7 @@ services:
       - --rpc-addr 0.0.0.0:33145
       - --advertise-rpc-addr redpanda-0:33145
   redpanda-1:
-    image: vectorized/redpanda:v21.11.2
+    image: vectorized/redpanda:v22.1.4
     container_name: redpanda-1
     ports:
       - '9011:9011'
@@ -38,7 +38,7 @@ services:
       - --rpc-addr 0.0.0.0:33146
       - --advertise-rpc-addr redpanda-1:33146
   redpanda-2:
-    image: vectorized/redpanda:v21.11.2
+    image: vectorized/redpanda:v22.1.4
     container_name: redpanda-2
     ports:
       - '9012:9012'

--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -24,7 +24,7 @@ use std::ops::{ControlFlow, Deref, Range};
 use std::sync::Arc;
 use time::OffsetDateTime;
 use tokio::sync::Mutex;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Compression {
@@ -145,18 +145,6 @@ impl PartitionClient {
             process_fetch_response(self.partition, &self.topic, response)
         })
         .await?;
-
-        // Redpanda never sends OffsetOutOfRange even when it should. "Luckily" it does not support deletions so we can
-        // implement a simple heuristic.
-        if partition.high_watermark.0 < offset {
-            warn!(
-                "This message looks like Redpanda wants to report a OffsetOutOfRange but doesn't."
-            );
-            return Err(Error::ServerError(
-                ProtocolError::OffsetOutOfRange,
-                String::from("Offset out of range"),
-            ));
-        }
 
         let records = extract_records(partition.records.0, offset)?;
 


### PR DESCRIPTION
Newer versions of Redpanda do not require the `OffsetOutOfBounds`
quirk anymore, so let's remove it. See #147 on why this is a good idea.
