### PR TITLE
fix: use compact arrays where needed

### DIFF
--- a/src/protocol/messages/create_topics.rs
+++ b/src/protocol/messages/create_topics.rs
@@ -199,7 +199,12 @@ where
         assert!(v <= 5);
 
         self.partition_index.write(writer)?;
-        self.broker_ids.write(writer)?;
+
+        if v >= 5 {
+            CompactArrayRef(self.broker_ids.0.as_deref()).write(writer)?;
+        } else {
+            self.broker_ids.write(writer)?;
+        }
 
         if v >= 5 {
             match self.tagged_fields.as_ref() {


### PR DESCRIPTION
Compact array representations were introduced at the same time as
compact strings and tagged fields. For arrays with versioned structures
we already use these. For primitive arrays however we did not use them
yet. The only message where this applies is CreateTopics and the broker
didn't seem to care that we've messed up the serialization of this one
field.

Compact arrays might be helpful for other message types as well, so this
is both a fix and some feature work.