### PR TITLE
refactor: make errors non-exhaustive

### DIFF
--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -4,6 +4,7 @@ pub use crate::messenger::RequestError;
 pub use crate::protocol::error::Error as ProtocolError;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Connection error: {0}")]
     Connection(#[from] crate::connection::Error),

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -23,6 +23,7 @@ pub type BrokerConnection = Arc<MessengerTransport>;
 pub type MessengerTransport = Messenger<BufStream<transport::Transport>>;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("error getting cluster metadata: {0}")]
     Metadata(#[from] RequestError),

--- a/src/connection/transport.rs
+++ b/src/connection/transport.rs
@@ -17,6 +17,7 @@ pub type TlsConfig = Option<Arc<rustls::ClientConfig>>;
 pub type TlsConfig = ();
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("IO Error: {0}")]
     IO(#[from] std::io::Error),

--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -117,6 +117,7 @@ pub struct Messenger<RW> {
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum RequestError {
     #[error("Cannot find matching version for: {api_key:?}")]
     NoVersionMatch { api_key: ApiKey },
@@ -154,6 +155,7 @@ pub enum RequestError {
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum SyncVersionsError {
     #[error("Did not found a version for ApiVersion that works with that broker")]
     NoWorkingVersion,

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -7,6 +7,7 @@ use super::primitives::Int16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(clippy::enum_variant_names)]
+#[non_exhaustive]
 pub enum Error {
     UnknownServerError,
     OffsetOutOfRange,

--- a/src/protocol/frame.rs
+++ b/src/protocol/frame.rs
@@ -15,6 +15,7 @@ use super::{
 };
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum ReadError {
     #[error("Cannot read data: {0}")]
     IO(#[from] std::io::Error),
@@ -74,6 +75,7 @@ where
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum WriteError {
     #[error("Cannot write data: {0}")]
     IO(#[from] std::io::Error),

--- a/src/protocol/messages/mod.rs
+++ b/src/protocol/messages/mod.rs
@@ -38,6 +38,7 @@ pub use produce::*;
 mod test_utils;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum ReadVersionedError {
     #[error("Read error: {0}")]
     ReadError(#[from] ReadError),
@@ -51,6 +52,7 @@ where
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum WriteVersionedError {
     #[error("Write error: {0}")]
     WriteError(#[from] WriteError),

--- a/src/protocol/traits.rs
+++ b/src/protocol/traits.rs
@@ -3,6 +3,7 @@ use std::io::{Read, Write};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum ReadError {
     #[error("Cannot read data: {0}")]
     IO(#[from] std::io::Error),
@@ -22,6 +23,7 @@ where
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum WriteError {
     #[error("Cannot write data: {0}")]
     IO(#[from] std::io::Error),


### PR DESCRIPTION
This makes it easier to add new error variants later w/o introducing
breaking changes.
