### PR TITLE
chore: `dotenv` -> `dotenvy`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ zstd = { version = "0.10", optional = true }
 [dev-dependencies]
 assert_matches = "1.5"
 criterion = { version = "0.3", features = ["async_tokio"] }
-dotenv = "0.15"
+dotenvy = "0.15.1"
 futures = "0.3"
 j4rs = "0.13"
 once_cell = "1.9"

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -315,7 +315,7 @@ impl RecordExt for Record {
 macro_rules! maybe_skip_kafka_integration {
     () => {{
         use std::env;
-        dotenv::dotenv().ok();
+        dotenvy::dotenv().ok();
 
         match (
             env::var("TEST_INTEGRATION").is_ok(),

--- a/tests/java_helper.rs
+++ b/tests/java_helper.rs
@@ -13,7 +13,7 @@ use time::OffsetDateTime;
 macro_rules! maybe_skip_java_interopt {
     () => {{
         use std::env;
-        dotenv::dotenv().ok();
+        dotenvy::dotenv().ok();
 
         if env::var("TEST_JAVA_INTEROPT").is_err() {
             return;

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -16,7 +16,7 @@ use time::OffsetDateTime;
 macro_rules! maybe_skip_kafka_integration {
     () => {{
         use std::env;
-        dotenv::dotenv().ok();
+        dotenvy::dotenv().ok();
 
         match (
             env::var("TEST_INTEGRATION").is_ok(),
@@ -80,7 +80,7 @@ macro_rules! maybe_skip_delete {
 macro_rules! maybe_skip_SOCKS_PROXY {
     () => {{
         use std::env;
-        dotenv::dotenv().ok();
+        dotenvy::dotenv().ok();
 
         match (env::var("SOCKS_PROXY").ok()) {
             Some(proxy) => proxy,


### PR DESCRIPTION
Use a maintained fork for `dotenv`.
