### PR TITLE
feat: pub ProducerClient for instrumentation hook

### DIFF
--- a/src/client/producer.rs
+++ b/src/client/producer.rs
@@ -240,13 +240,14 @@ pub struct BatchProducerBuilder {
 }
 
 impl BatchProducerBuilder {
-    /// Build a new `BatchProducer`
+    /// Build a new `BatchProducer`.
     pub fn new(client: Arc<PartitionClient>) -> Self {
         Self::new_with_client(client)
     }
 
-    /// Internal API for creating with any `dyn ProducerClient`
-    fn new_with_client(client: Arc<dyn ProducerClient>) -> Self {
+    /// Construct a [`BatchProducer`] with a dynamically dispatched
+    /// [`ProducerClient`] implementation.
+    pub fn new_with_client(client: Arc<dyn ProducerClient>) -> Self {
         Self {
             client,
             linger: Duration::from_millis(5),
@@ -283,8 +284,18 @@ impl BatchProducerBuilder {
     }
 }
 
-// A trait wrapper to allow mocking
-trait ProducerClient: std::fmt::Debug + Send + Sync {
+/// The [`ProducerClient`] provides an abstraction over a Kafka client than can
+/// produce a record.
+///
+/// Implementing this trait allows user code to inspect the low-level Kafka
+/// [`Record`] instances being published to Kafka, as well as the result of the
+/// produce call.
+///
+/// Most users will want to use the [`BatchProducer`] implementation of this
+/// trait.
+pub trait ProducerClient: std::fmt::Debug + Send + Sync {
+    /// Write the set of `records` to the Kafka broker, using the specified
+    /// `compression` algorithm.
     fn produce(
         &self,
         records: Vec<Record>,


### PR DESCRIPTION
Marks the `ProducerClient` as pub, so external code can inject instrumentation over the kafka client via decorators when constructing the `BatchProducer`.

This allows:

* Recording the latency of the low-level produce call independent of the aggregation logic (just the serialisation / protocol overhead / network I/O / etc)
* Inspecting the `Record` payloads on the producer side (somewhat related to https://github.com/influxdata/influxdb_iox/issues/5117)
* Emitting metrics for `produce()` errors, etc

This is not a breaking API change.

---

* feat: pub ProducerClient for instrumentation hook (9bf370a)

      This commit changes the visibility of the ProducerClient abstraction and the
      associated BatchProducer constructor method (used internally to swap out the
      real client impl with a mock for testing purposes.)

      This allows external code to optionally "hook" into the lower-level Kafka
      client calls, in order to inspect the Records being pushed to Kafka /
      instrument & evaluate produce errors / measure produce latency / etc.