### PR TITLE
feat: metadata cache for leader discovery

### DIFF
--- a/src/client/controller.rs
+++ b/src/client/controller.rs
@@ -7,7 +7,9 @@ use tracing::{debug, error, info};
 use crate::{
     backoff::{Backoff, BackoffConfig},
     client::{Error, Result},
-    connection::{BrokerCache, BrokerConnection, BrokerConnector, MessengerTransport},
+    connection::{
+        BrokerCache, BrokerConnection, BrokerConnector, MessengerTransport, MetadataLookupMode,
+    },
     messenger::RequestError,
     protocol::{
         error::Error as ProtocolError,
@@ -93,7 +95,7 @@ impl ControllerClient {
         // Request an uncached, fresh copy of the metadata.
         let metadata = self
             .brokers
-            .request_metadata(None, Some(vec![]), false)
+            .request_metadata(MetadataLookupMode::ArbitraryBroker, Some(vec![]))
             .await?;
 
         let controller_id = metadata

--- a/src/client/controller.rs
+++ b/src/client/controller.rs
@@ -80,12 +80,21 @@ impl ControllerClient {
                 }),
             }
         })
-        .await
+        .await?;
+
+        // Refresh the cache now there is definitely a new topic to observe.
+        let _ = self.brokers.refresh_metadata().await;
+
+        Ok(())
     }
 
     /// Retrieve the broker ID of the controller
     async fn get_controller_id(&self) -> Result<i32> {
-        let metadata = self.brokers.request_metadata(None, Some(vec![])).await?;
+        // Request an uncached, fresh copy of the metadata.
+        let metadata = self
+            .brokers
+            .request_metadata(None, Some(vec![]), false)
+            .await?;
 
         let controller_id = metadata
             .controller_id

--- a/src/client/metadata_cache.rs
+++ b/src/client/metadata_cache.rs
@@ -1,0 +1,154 @@
+use parking_lot::Mutex;
+use tracing::debug;
+
+use crate::protocol::messages::MetadataResponse;
+
+/// A [`MetadataCache`] provides look-aside caching of [`MetadataResponse`]
+/// instances.
+#[derive(Debug, Default)]
+pub(crate) struct MetadataCache {
+    cache: Mutex<Option<MetadataResponse>>,
+}
+
+impl MetadataCache {
+    /// Grab a copy of the cached metadata.
+    ///
+    /// If `topics` is `Some` the returned metadata contains topics that are
+    /// filtered to match by name. If a topic name is specified that doesn't
+    /// exist in the cached metadata, the cache is invalidated.
+    pub(crate) fn get(&self, topics: &Option<Vec<String>>) -> Option<MetadataResponse> {
+        let mut m = self.cache.lock().clone()?;
+
+        // If the caller requested a subset of topics, filter the cached result
+        // to ensure only the expected topics are present.
+        if let Some(want) = topics {
+            // Filter out any topics the caller did not ask for.
+            m.topics = m
+                .topics
+                .into_iter()
+                .filter(|t| want.contains(&t.name.0))
+                .collect();
+
+            // Validate the resulting number of topics in the metadata response.
+            if m.topics.len() != want.len() {
+                // The caller requested more topics than the cached entry
+                // contains. This may indicate the cached entry is stale.
+                //
+                // In order to maximise correctness, do not use the cached entry
+                // and invalidate this cache, at the expense of cache thrashing
+                // if a caller keeps requesting metadata for a non-existent
+                // topic.
+                debug!("cached metadata query for unknown topic");
+                self.invalidate();
+                return None;
+            }
+        }
+
+        debug!(?m, "using cached metadata response");
+
+        Some(m)
+    }
+
+    pub(crate) fn invalidate(&self) {
+        *self.cache.lock() = None;
+        debug!("invalidated metadata cache");
+    }
+
+    pub(crate) fn update(&self, m: MetadataResponse) {
+        *self.cache.lock() = Some(m);
+        debug!("updated metadata cache");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::protocol::{
+        messages::MetadataResponseTopic,
+        primitives::{Int32, String_},
+    };
+
+    use super::*;
+
+    /// Generate a MetadataResponse with the specified topics.
+    fn response_with_topics(topics: Option<&'static [&'static str]>) -> MetadataResponse {
+        let topics = topics
+            .into_iter()
+            .flatten()
+            .map(|t| MetadataResponseTopic {
+                name: String_(t.to_string()),
+                error: Default::default(),
+                is_internal: Default::default(),
+                partitions: Default::default(),
+            })
+            .collect();
+
+        MetadataResponse {
+            throttle_time_ms: Some(Int32(42)),
+            brokers: Default::default(),
+            cluster_id: Default::default(),
+            controller_id: Default::default(),
+            topics,
+        }
+    }
+
+    #[test]
+    fn test_get() {
+        let cache = MetadataCache::default();
+        assert!(cache.get(&None).is_none());
+
+        let m = response_with_topics(None);
+        cache.update(m.clone());
+
+        let got = cache.get(&None).expect("should have cached entry");
+        assert_eq!(m, got);
+    }
+
+    #[test]
+    fn test_get_topic_subset_filtered() {
+        let cache = MetadataCache::default();
+        cache.update(response_with_topics(Some(&["bananas", "platanos"])));
+
+        // Request a subset of the topics
+        let got = cache
+            .get(&Some(vec!["bananas".to_string()]))
+            .expect("should have cached entry");
+        assert_eq!(response_with_topics(Some(&["bananas"])), got);
+
+        let got = cache.get(&Some(vec![])).expect("should have cached entry");
+        assert_eq!(response_with_topics(Some(&[])), got);
+
+        // A request for "None" actually means "all of them".
+        let got = cache.get(&None).expect("should have cached entry");
+        assert_eq!(response_with_topics(Some(&["bananas", "platanos"])), got);
+    }
+
+    #[test]
+    fn test_get_missing_topic_invalidate() {
+        let cache = MetadataCache::default();
+        cache.update(response_with_topics(Some(&["bananas", "platanos"])));
+
+        assert!(cache.get(&Some(vec!["bananas".to_string()])).is_some());
+
+        // Request an unknown topic and assert the cache was invalidated as a
+        // result
+        assert!(cache.get(&Some(vec!["goats".to_string()])).is_none());
+        // The previously successful get should now return no cached entry
+        assert!(cache.get(&Some(vec!["bananas".to_string()])).is_none());
+    }
+
+    #[test]
+    fn test_explicit_invalidate() {
+        let cache = MetadataCache::default();
+        cache.update(MetadataResponse {
+            throttle_time_ms: Default::default(),
+            brokers: Default::default(),
+            cluster_id: Default::default(),
+            controller_id: Default::default(),
+            topics: Default::default(),
+        });
+
+        assert!(cache.get(&None).is_some());
+        cache.invalidate();
+        assert!(cache.get(&None).is_none());
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use crate::{
     client::partition::PartitionClient,
-    connection::{BrokerConnector, TlsConfig},
+    connection::{BrokerConnector, MetadataLookupMode, TlsConfig},
     protocol::primitives::Boolean,
     topic::Topic,
 };
@@ -138,7 +138,10 @@ impl Client {
         //
         // Because this is an unconstrained metadata request (all topics) it
         // will update the cached metadata entry.
-        let response = self.brokers.request_metadata(None, None, false).await?;
+        let response = self
+            .brokers
+            .request_metadata(MetadataLookupMode::ArbitraryBroker, None)
+            .await?;
 
         Ok(response
             .topics

--- a/src/protocol/messages/metadata.rs
+++ b/src/protocol/messages/metadata.rs
@@ -90,7 +90,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct MetadataResponse {
     /// The duration in milliseconds for which the request was throttled due to
     /// a quota violation, or zero if the request did not violate any quota.
@@ -139,7 +139,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct MetadataResponseBroker {
     /// The broker ID
     pub node_id: Int32,
@@ -173,7 +173,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct MetadataResponseTopic {
     /// The topic error if any
     pub error: Option<Error>,
@@ -207,7 +207,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct MetadataResponsePartition {
     /// The partition error if any
     pub error: Option<Error>,

--- a/src/protocol/primitives.rs
+++ b/src/protocol/primitives.rs
@@ -281,7 +281,7 @@ where
 ///
 /// For non-null strings, first the length N is given as an INT16. Then N bytes follow which are the UTF-8 encoding of
 /// the character sequence. A null value is encoded with length of -1 and there are no following bytes.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Clone)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct NullableString(pub Option<String>);
 
@@ -329,7 +329,7 @@ where
 ///
 /// First the length N is given as an INT16. Then N bytes follow which are the UTF-8 encoding of the character
 /// sequence. Length must not be negative.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct String_(pub String);
 
@@ -575,7 +575,7 @@ where
 /// Type T can be either a primitive type (e.g. STRING) or a structure. First, the length N is given as an INT32. Then
 /// N instances of type T follow. A null array is represented with a length of -1. In protocol documentation an array
 /// of T instances is referred to as `[T]`.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct Array<T>(pub Option<Vec<T>>);
 


### PR DESCRIPTION
This PR halves the number of requests needed by the `PartitionClient` for leadership discovery in the common/happy path.

Ideally we would perform a metadata request, and then use that to initialise all the `PartitionClient` a user needs in one go and hand them to the user - however because a `PartitionClient` is lazily initialised by a call to [`Client::partition_client()`] at any point in time, it is not possible to perform batch initialisation in this way (but is a slightly nicer UX).

Instead the approach this PR takes is to maintain a metadata cache (invalidated & updated automatically as a side effect of normal usage) and use the cached metadata to optimistically select a partition's leader. This is then validated by contacting the potential leader to assert it indeed is the actual leader (existing code). I expect this cache will also help reduce recovery times when a cluster disruption occurs.

Testing shows this can lead to ~15% speed-up when attempting to initialise a large number of `PartitionClient` instances, increasing as the I/O latency increases. Test performed on a local, single node, no-replica cluster with no active workloads, so the "real world" improvement is likely much greater.

[`Client::partition_client()`]:https://github.com/influxdata/rskafka/blob/706cc67c6cbed84651a4647f21caf497fea52fc6/src/client/mod.rs#L118-L129

---

* feat: metadata cache for leader discovery (706cc67)

      Adds a MetadataCache, used by the BrokerCache to optimistically halve the
      number of broker requests made during leader discovery.