### PR TITLE
fix: pre-warm cache broker connections

### DIFF
--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -117,9 +117,7 @@ impl PartitionClient {
             &*brokers,
             "leader_detection",
             || async move {
-                scope
-                    .get_leader(MetadataLookupMode::CachedArbitrary)
-                    .await?;
+                scope.get().await?;
                 Ok(())
             },
         )


### PR DESCRIPTION
Changes the func called in the pre-warm step introduced in #165 - `get_leader()` discovers the leader, but only `get()` caches the connection!

Doh!

---

* fix: pre-warm cache broker connections (64211b5)

      PR #165 added leader discovery at initialisation time and intended to also
      cache the broker connection but called the wrong func.

      This commit calls get() which establishes & caches the broker connection.