### PR TITLE
chore: fix `cargo bench -- --save-baseline`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,11 @@ transport-tls = ["rustls", "tokio-rustls"]
 
 unstable-fuzzing = []
 
+[lib]
+# For `cargo bench -- --save-baseline ...`
+# See https://github.com/bheisler/criterion.rs/issues/275.
+bench = false
+
 [[bench]]
 name = "throughput"
 harness = false

--- a/src/client/producer.rs
+++ b/src/client/producer.rs
@@ -608,9 +608,9 @@ mod tests {
 
             let mut futures = FuturesOrdered::new();
 
-            futures.push(producer.produce(record.clone()));
-            futures.push(producer.produce(record.clone()));
-            futures.push(producer.produce(record.clone()));
+            futures.push_back(producer.produce(record.clone()));
+            futures.push_back(producer.produce(record.clone()));
+            futures.push_back(producer.produce(record.clone()));
 
             let assert_ok = |a: Result<Option<Result<_, _>>, _>, expected: i64| {
                 let offset = a


### PR DESCRIPTION
Inspired by https://github.com/influxdata/influxdb_iox/pull/5400.