### PR TITLE
ci: bump redpanda version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
     # setup multiple docker images (see https://circleci.com/docs/2.0/configuration-reference/#docker)
     docker:
       - image: quay.io/influxdb/rust:ci
-      - image: vectorized/redpanda:v22.1.4
+      - image: vectorized/redpanda:v22.2.1
         name: redpanda-0
         command:
           - redpanda
@@ -152,7 +152,7 @@ jobs:
           - --check=false
           - --kafka-addr redpanda-0:9092
           - --rpc-addr redpanda-0:33145
-      - image: vectorized/redpanda:v22.1.4
+      - image: vectorized/redpanda:v22.2.1
         name: redpanda-1
         command:
           - redpanda
@@ -166,7 +166,7 @@ jobs:
           - --kafka-addr redpanda-1:9092
           - --rpc-addr redpanda-1:33145
           - --seeds redpanda-0:33145
-      - image: vectorized/redpanda:v22.1.4
+      - image: vectorized/redpanda:v22.2.1
         name: redpanda-2
         command:
           - redpanda


### PR DESCRIPTION
I have had trouble running this locally, and there have been [significant changes](https://github.com/redpanda-data/redpanda/releases/tag/v22.2.1).

---

* ci: bump redpanda version (848f511)