### PR TITLE
fix: update redpanda, fix issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
     # setup multiple docker images (see https://circleci.com/docs/2.0/configuration-reference/#docker)
     docker:
       - image: quay.io/influxdb/rust:ci
-      - image: vectorized/redpanda:v22.1.4
+      - image: vectorized/redpanda:v22.2.1
         name: redpanda-0
         command:
           - redpanda
@@ -161,7 +161,7 @@ jobs:
           - --check=false
           - --kafka-addr redpanda-0:9092
           - --rpc-addr redpanda-0:33145
-      - image: vectorized/redpanda:v22.1.4
+      - image: vectorized/redpanda:v22.2.1
         name: redpanda-1
         command:
           - redpanda
@@ -175,7 +175,7 @@ jobs:
           - --kafka-addr redpanda-1:9092
           - --rpc-addr redpanda-1:33145
           - --seeds redpanda-0:33145
-      - image: vectorized/redpanda:v22.1.4
+      - image: vectorized/redpanda:v22.2.1
         name: redpanda-2
         command:
           - redpanda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,7 @@ jobs:
           - --check=false
           - --kafka-addr redpanda-0:9092
           - --rpc-addr redpanda-0:33145
+          - --set redpanda.auto_create_topics_enabled=false
       - image: vectorized/redpanda:v22.2.1
         name: redpanda-1
         command:
@@ -175,6 +176,7 @@ jobs:
           - --kafka-addr redpanda-1:9092
           - --rpc-addr redpanda-1:33145
           - --seeds redpanda-0:33145
+          - --set redpanda.auto_create_topics_enabled=false
       - image: vectorized/redpanda:v22.2.1
         name: redpanda-2
         command:
@@ -189,6 +191,7 @@ jobs:
           - --kafka-addr redpanda-2:9092
           - --rpc-addr redpanda-2:33145
           - --seeds redpanda-0:33145
+          - --set redpanda.auto_create_topics_enabled=false
       - image: serjs/go-socks5-proxy
         name: proxy
     resource_class: xlarge  # use of a smaller executor tends crashes on link
@@ -243,6 +246,7 @@ jobs:
           - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
           - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka-0:9092,EXTERNAL://kafka-0:9093
           - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+          - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
       - image: docker.io/bitnami/kafka:3
         name: kafka-1
         environment:
@@ -253,6 +257,7 @@ jobs:
           - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
           - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka-1:9092,EXTERNAL://kafka-1:9093
           - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+          - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
       - image: docker.io/bitnami/kafka:3
         name: kafka-2
         environment:
@@ -263,6 +268,7 @@ jobs:
           - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
           - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka-2:9092,EXTERNAL://kafka-2:9093
           - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+          - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
       - image: serjs/go-socks5-proxy
         name: proxy
     resource_class: xlarge  # use of a smaller executor tends crashes on link

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It will be a good fit for workloads that:
 use rskafka::{
     client::{
         ClientBuilder,
-        partition::Compression,
+        partition::{Compression, PartitionClientBindMode},
     },
     record::Record,
 };
@@ -58,6 +58,7 @@ let partition_client = client
     .partition_client(
         topic.to_owned(),
         0,  // partition
+        PartitionClientBindMode::Strong,
      )
      .await
     .unwrap();

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It will be a good fit for workloads that:
 use rskafka::{
     client::{
         ClientBuilder,
-        partition::{Compression, PartitionClientBindMode},
+        partition::{Compression, UnknownTopicHandling},
     },
     record::Record,
 };
@@ -58,7 +58,7 @@ let partition_client = client
     .partition_client(
         topic.to_owned(),
         0,  // partition
-        PartitionClientBindMode::Strong,
+        UnknownTopicHandling::Retry,
      )
      .await
     .unwrap();

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -22,7 +22,7 @@ use rdkafka::{
 use rskafka::{
     client::{
         consumer::{StartOffset, StreamConsumerBuilder as RsStreamConsumerBuilder},
-        partition::{Compression, PartitionClient, PartitionClientBindMode},
+        partition::{Compression, PartitionClient, UnknownTopicHandling},
         producer::{aggregator::RecordAggregator, BatchProducerBuilder},
         ClientBuilder,
     },
@@ -449,7 +449,7 @@ async fn setup_rskafka(connection: Vec<String>) -> PartitionClient {
         .unwrap();
 
     client
-        .partition_client(topic_name, 0, PartitionClientBindMode::Strong)
+        .partition_client(topic_name, 0, UnknownTopicHandling::Retry)
         .await
         .unwrap()
 }

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -22,7 +22,7 @@ use rdkafka::{
 use rskafka::{
     client::{
         consumer::{StartOffset, StreamConsumerBuilder as RsStreamConsumerBuilder},
-        partition::{Compression, PartitionClient},
+        partition::{Compression, PartitionClient, PartitionClientBindMode},
         producer::{aggregator::RecordAggregator, BatchProducerBuilder},
         ClientBuilder,
     },
@@ -448,7 +448,10 @@ async fn setup_rskafka(connection: Vec<String>) -> PartitionClient {
         .await
         .unwrap();
 
-    client.partition_client(topic_name, 0).await.unwrap()
+    client
+        .partition_client(topic_name, 0, PartitionClientBindMode::Strong)
+        .await
+        .unwrap()
 }
 
 static LOG_SETUP: Once = Once::new();

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -22,6 +22,7 @@ services:
       - KAFKA_CFG_LISTENERS=CLIENT://:9000,EXTERNAL://:9010,FOR_PROXY://:9020
       - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka-0:9000,EXTERNAL://localhost:9010,FOR_PROXY://kafka-0:9020
       - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
     volumes:
       - kafka_0_data:/bitnami/kafka
     depends_on:
@@ -38,6 +39,7 @@ services:
       - KAFKA_CFG_LISTENERS=CLIENT://:9000,EXTERNAL://:9011,FOR_PROXY://:9021
       - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka-1:9000,EXTERNAL://localhost:9011,FOR_PROXY://kafka-1:9021
       - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
     volumes:
       - kafka_1_data:/bitnami/kafka
     depends_on:
@@ -54,6 +56,7 @@ services:
       - KAFKA_CFG_LISTENERS=CLIENT://:9000,EXTERNAL://:9012,FOR_PROXY://:9022
       - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka-2:9000,EXTERNAL://localhost:9012,FOR_PROXY://kafka-2:9022
       - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=false
     volumes:
       - kafka_2_data:/bitnami/kafka
     depends_on:

--- a/docker-compose-redpanda.yml
+++ b/docker-compose-redpanda.yml
@@ -19,6 +19,7 @@ services:
       - --advertise-kafka-addr EXTERNAL://127.0.0.1:9010,FOR_PROXY://redpanda-0:9020
       - --rpc-addr 0.0.0.0:33145
       - --advertise-rpc-addr redpanda-0:33145
+      - --set redpanda.auto_create_topics_enabled=false
   redpanda-1:
     image: vectorized/redpanda:v22.2.1
     container_name: redpanda-1
@@ -38,6 +39,7 @@ services:
       - --advertise-kafka-addr EXTERNAL://127.0.0.1:9011,FOR_PROXY://redpanda-1:9021
       - --rpc-addr 0.0.0.0:33146
       - --advertise-rpc-addr redpanda-1:33146
+      - --set redpanda.auto_create_topics_enabled=false
   redpanda-2:
     image: vectorized/redpanda:v22.2.1
     container_name: redpanda-2
@@ -57,6 +59,7 @@ services:
       - --advertise-kafka-addr EXTERNAL://127.0.0.1:9012,FOR_PROXY://redpanda-2:9022
       - --rpc-addr 0.0.0.0:33147
       - --advertise-rpc-addr redpanda-2:33147
+      - --set redpanda.auto_create_topics_enabled=false
   proxy:
     image: serjs/go-socks5-proxy
     ports:

--- a/docker-compose-redpanda.yml
+++ b/docker-compose-redpanda.yml
@@ -2,7 +2,7 @@
 version: '3.7'
 services:
   redpanda-0:
-    image: vectorized/redpanda:v22.1.4
+    image: vectorized/redpanda:v22.2.1
     container_name: redpanda-0
     ports:
       - '9010:9010'
@@ -20,7 +20,7 @@ services:
       - --rpc-addr 0.0.0.0:33145
       - --advertise-rpc-addr redpanda-0:33145
   redpanda-1:
-    image: vectorized/redpanda:v22.1.4
+    image: vectorized/redpanda:v22.2.1
     container_name: redpanda-1
     ports:
       - '9011:9011'
@@ -39,7 +39,7 @@ services:
       - --rpc-addr 0.0.0.0:33146
       - --advertise-rpc-addr redpanda-1:33146
   redpanda-2:
-    image: vectorized/redpanda:v22.1.4
+    image: vectorized/redpanda:v22.2.1
     container_name: redpanda-2
     ports:
       - '9012:9012'

--- a/src/client/consumer.rs
+++ b/src/client/consumer.rs
@@ -10,7 +10,7 @@
 //!         StartOffset,
 //!         StreamConsumerBuilder,
 //!     },
-//!     partition::PartitionClientBindMode,
+//!     partition::UnknownTopicHandling,
 //! };
 //! use std::sync::Arc;
 //!
@@ -21,7 +21,7 @@
 //!     client.partition_client(
 //!         "my_topic",
 //!         0,
-//!         PartitionClientBindMode::Strong,
+//!         UnknownTopicHandling::Retry,
 //!     ).await.unwrap()
 //! );
 //!

--- a/src/client/consumer.rs
+++ b/src/client/consumer.rs
@@ -10,6 +10,7 @@
 //!         StartOffset,
 //!         StreamConsumerBuilder,
 //!     },
+//!     partition::PartitionClientBindMode,
 //! };
 //! use std::sync::Arc;
 //!
@@ -17,7 +18,11 @@
 //! let connection = "localhost:9093".to_owned();
 //! let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
 //! let partition_client = Arc::new(
-//!     client.partition_client("my_topic", 0).await.unwrap()
+//!     client.partition_client(
+//!         "my_topic",
+//!         0,
+//!         PartitionClientBindMode::Strong,
+//!     ).await.unwrap()
 //! );
 //!
 //! // construct stream consumer

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -93,6 +93,9 @@ pub enum Error {
 
     #[error("All retries failed: {0}")]
     RetryFailed(#[from] crate::backoff::BackoffError),
+
+    #[error("Timeout")]
+    Timeout,
 }
 
 impl Error {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -18,7 +18,7 @@ pub mod producer;
 
 use error::{Error, Result};
 
-use self::controller::ControllerClient;
+use self::{controller::ControllerClient, partition::PartitionClientBindMode};
 
 #[derive(Debug, Error)]
 pub enum ProduceError {
@@ -120,8 +120,15 @@ impl Client {
         &self,
         topic: impl Into<String> + Send,
         partition: i32,
+        bind_mode: PartitionClientBindMode,
     ) -> Result<PartitionClient> {
-        PartitionClient::new(topic.into(), partition, Arc::clone(&self.brokers)).await
+        PartitionClient::new(
+            topic.into(),
+            partition,
+            Arc::clone(&self.brokers),
+            bind_mode,
+        )
+        .await
     }
 
     /// Returns a list of topics in the cluster

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -18,7 +18,7 @@ pub mod producer;
 
 use error::{Error, Result};
 
-use self::{controller::ControllerClient, partition::PartitionClientBindMode};
+use self::{controller::ControllerClient, partition::UnknownTopicHandling};
 
 #[derive(Debug, Error)]
 pub enum ProduceError {
@@ -120,13 +120,13 @@ impl Client {
         &self,
         topic: impl Into<String> + Send,
         partition: i32,
-        bind_mode: PartitionClientBindMode,
+        unknown_topic_handling: UnknownTopicHandling,
     ) -> Result<PartitionClient> {
         PartitionClient::new(
             topic.into(),
             partition,
             Arc::clone(&self.brokers),
-            bind_mode,
+            unknown_topic_handling,
         )
         .await
     }

--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -36,8 +36,8 @@ use super::error::ServerErrorResponse;
 ///
 /// Under some circumstances and broker implementations, you might face a [`ProtocolError::UnknownTopicOrPartition`]
 /// for nearly all operations directly after topic/partition creation. Since the Kafka protocol offers no (at least
-/// to our knowledge) we to differentiate between "a topic/partition actually does not exist" and "our multiverse
-/// split brain is not synced up yet", we can only offer your this manual way to wait for the existence.
+/// to our knowledge) way to differentiate between "a topic/partition actually does not exist" and "our multiverse
+/// split brain is not synced up yet", we can only offer you a manual way to wait for topic existence.
 ///
 /// We offer the following ways to deal with this:
 ///

--- a/src/client/producer.rs
+++ b/src/client/producer.rs
@@ -42,6 +42,7 @@
 //! use rskafka::{
 //!     client::{
 //!         ClientBuilder,
+//!         partition::PartitionClientBindMode,
 //!         producer::{
 //!             aggregator::RecordAggregator,
 //!             BatchProducerBuilder,
@@ -60,7 +61,11 @@
 //! let connection = "localhost:9093".to_owned();
 //! let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
 //! let partition_client = Arc::new(
-//!     client.partition_client("my_topic", 0).await.unwrap()
+//!     client.partition_client(
+//!         "my_topic",
+//!         0,
+//!         PartitionClientBindMode::Strong,
+//!     ).await.unwrap()
 //! );
 //!
 //! // construct batch producer
@@ -91,6 +96,7 @@
 //! use rskafka::{
 //!     client::{
 //!         ClientBuilder,
+//!         partition::PartitionClientBindMode,
 //!         producer::{
 //!             aggregator::{
 //!                 Aggregator,
@@ -177,7 +183,11 @@
 //! let connection = "localhost:9093".to_owned();
 //! let client = ClientBuilder::new(vec![connection]).build().await.unwrap();
 //! let partition_client = Arc::new(
-//!     client.partition_client("my_topic", 0).await.unwrap()
+//!     client.partition_client(
+//!         "my_topic",
+//!         0,
+//!         PartitionClientBindMode::Strong,
+//!     ).await.unwrap()
 //! );
 //!
 //! // construct batch producer

--- a/src/client/producer.rs
+++ b/src/client/producer.rs
@@ -42,7 +42,7 @@
 //! use rskafka::{
 //!     client::{
 //!         ClientBuilder,
-//!         partition::PartitionClientBindMode,
+//!         partition::UnknownTopicHandling,
 //!         producer::{
 //!             aggregator::RecordAggregator,
 //!             BatchProducerBuilder,
@@ -64,7 +64,7 @@
 //!     client.partition_client(
 //!         "my_topic",
 //!         0,
-//!         PartitionClientBindMode::Strong,
+//!         UnknownTopicHandling::Retry,
 //!     ).await.unwrap()
 //! );
 //!
@@ -96,7 +96,7 @@
 //! use rskafka::{
 //!     client::{
 //!         ClientBuilder,
-//!         partition::PartitionClientBindMode,
+//!         partition::UnknownTopicHandling,
 //!         producer::{
 //!             aggregator::{
 //!                 Aggregator,
@@ -186,7 +186,7 @@
 //!     client.partition_client(
 //!         "my_topic",
 //!         0,
-//!         PartitionClientBindMode::Strong,
+//!         UnknownTopicHandling::Retry,
 //!     ).await.unwrap()
 //! );
 //!

--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -302,7 +302,9 @@ where
             request_api_key: R::API_KEY,
             request_api_version: body_api_version,
             correlation_id: Int32(correlation_id),
-            client_id: Some(NullableString(None)),
+            // Technically we don't need to send a client_id, but newer redpanda version fail to parse the message
+            // without it. See https://github.com/influxdata/rskafka/issues/169 .
+            client_id: Some(NullableString(Some(String::from(env!("CARGO_PKG_NAME"))))),
             tagged_fields: Some(TaggedFields::default()),
         };
         let header_version = if use_tagged_fields_in_request {
@@ -1110,7 +1112,7 @@ mod tests {
                         request_api_key: ApiKey::ApiVersions,
                         request_api_version: ApiVersion(Int16(0)),
                         correlation_id: Int32(correlation_id),
-                        client_id: Some(NullableString(None)),
+                        client_id: Some(NullableString(Some(String::from(env!("CARGO_PKG_NAME"))))),
                         tagged_fields: None,
                     }
                 );

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -2,7 +2,7 @@ use assert_matches::assert_matches;
 use rskafka::{
     client::{
         error::{Error as ClientError, ProtocolError, ServerErrorResponse},
-        partition::{Compression, OffsetAt, PartitionClientBindMode},
+        partition::{Compression, OffsetAt, UnknownTopicHandling},
         ClientBuilder,
     },
     record::{Record, RecordAndOffset},
@@ -89,7 +89,7 @@ async fn test_partition_client() {
         .unwrap();
 
     let partition_client = client
-        .partition_client(topic_name.clone(), 0, PartitionClientBindMode::Strong)
+        .partition_client(topic_name.clone(), 0, UnknownTopicHandling::Retry)
         .await
         .unwrap();
     assert_eq!(partition_client.topic(), &topic_name);
@@ -109,7 +109,7 @@ async fn test_non_existing_partition() {
 
     tokio::time::timeout(Duration::from_millis(100), async {
         client
-            .partition_client(topic_name.clone(), 0, PartitionClientBindMode::Strong)
+            .partition_client(topic_name.clone(), 0, UnknownTopicHandling::Retry)
             .await
             .unwrap();
     })
@@ -117,7 +117,7 @@ async fn test_non_existing_partition() {
     .unwrap_err();
 
     let err = client
-        .partition_client(topic_name.clone(), 0, PartitionClientBindMode::Weak)
+        .partition_client(topic_name.clone(), 0, UnknownTopicHandling::Error)
         .await
         .unwrap_err();
     assert_matches!(
@@ -199,7 +199,7 @@ async fn test_socks5() {
         .unwrap();
 
     let partition_client = client
-        .partition_client(topic_name, 0, PartitionClientBindMode::Strong)
+        .partition_client(topic_name, 0, UnknownTopicHandling::Retry)
         .await
         .unwrap();
 
@@ -234,7 +234,7 @@ async fn test_produce_empty() {
         .unwrap();
 
     let partition_client = client
-        .partition_client(&topic_name, 1, PartitionClientBindMode::Strong)
+        .partition_client(&topic_name, 1, UnknownTopicHandling::Retry)
         .await
         .unwrap();
     partition_client
@@ -259,7 +259,7 @@ async fn test_consume_empty() {
         .unwrap();
 
     let partition_client = client
-        .partition_client(&topic_name, 1, PartitionClientBindMode::Strong)
+        .partition_client(&topic_name, 1, UnknownTopicHandling::Retry)
         .await
         .unwrap();
     let (records, watermark) = partition_client
@@ -286,7 +286,7 @@ async fn test_consume_offset_out_of_range() {
         .unwrap();
 
     let partition_client = client
-        .partition_client(&topic_name, 1, PartitionClientBindMode::Strong)
+        .partition_client(&topic_name, 1, UnknownTopicHandling::Retry)
         .await
         .unwrap();
     let record = record(b"");
@@ -329,7 +329,7 @@ async fn test_get_offset() {
         .unwrap();
 
     let partition_client = client
-        .partition_client(topic_name.clone(), 0, PartitionClientBindMode::Strong)
+        .partition_client(topic_name.clone(), 0, UnknownTopicHandling::Retry)
         .await
         .unwrap();
 
@@ -394,7 +394,7 @@ async fn test_produce_consume_size_cutoff() {
 
     let partition_client = Arc::new(
         client
-            .partition_client(&topic_name, 0, PartitionClientBindMode::Strong)
+            .partition_client(&topic_name, 0, UnknownTopicHandling::Retry)
             .await
             .unwrap(),
     );
@@ -471,7 +471,7 @@ async fn test_consume_midbatch() {
         .unwrap();
 
     let partition_client = client
-        .partition_client(&topic_name, 0, PartitionClientBindMode::Strong)
+        .partition_client(&topic_name, 0, UnknownTopicHandling::Retry)
         .await
         .unwrap();
 
@@ -519,7 +519,7 @@ async fn test_delete_records() {
         .unwrap();
 
     let partition_client = client
-        .partition_client(&topic_name, 0, PartitionClientBindMode::Strong)
+        .partition_client(&topic_name, 0, UnknownTopicHandling::Retry)
         .await
         .unwrap();
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,8 +1,8 @@
 use assert_matches::assert_matches;
 use rskafka::{
     client::{
-        error::{Error as ClientError, ProtocolError},
-        partition::{Compression, OffsetAt},
+        error::{Error as ClientError, ProtocolError, ServerErrorResponse},
+        partition::{Compression, OffsetAt, PartitionClientBindMode},
         ClientBuilder,
     },
     record::{Record, RecordAndOffset},
@@ -89,11 +89,44 @@ async fn test_partition_client() {
         .unwrap();
 
     let partition_client = client
-        .partition_client(topic_name.clone(), 0)
+        .partition_client(topic_name.clone(), 0, PartitionClientBindMode::Strong)
         .await
         .unwrap();
     assert_eq!(partition_client.topic(), &topic_name);
     assert_eq!(partition_client.partition(), 0);
+}
+
+#[tokio::test]
+async fn test_non_existing_partition() {
+    maybe_start_logging();
+
+    let connection = maybe_skip_kafka_integration!();
+    let topic_name = random_topic_name();
+
+    let client = ClientBuilder::new(connection).build().await.unwrap();
+
+    // do NOT create the topic
+
+    tokio::time::timeout(Duration::from_millis(100), async {
+        client
+            .partition_client(topic_name.clone(), 0, PartitionClientBindMode::Strong)
+            .await
+            .unwrap();
+    })
+    .await
+    .unwrap_err();
+
+    let err = client
+        .partition_client(topic_name.clone(), 0, PartitionClientBindMode::Weak)
+        .await
+        .unwrap_err();
+    assert_matches!(
+        err,
+        ClientError::ServerError {
+            protocol_error: ProtocolError::UnknownTopicOrPartition,
+            ..
+        }
+    );
 }
 
 // Disabled as currently no TLS integration tests
@@ -165,7 +198,10 @@ async fn test_socks5() {
         .await
         .unwrap();
 
-    let partition_client = client.partition_client(topic_name, 0).await.unwrap();
+    let partition_client = client
+        .partition_client(topic_name, 0, PartitionClientBindMode::Strong)
+        .await
+        .unwrap();
 
     let record = record(b"");
     partition_client
@@ -197,7 +233,10 @@ async fn test_produce_empty() {
         .await
         .unwrap();
 
-    let partition_client = client.partition_client(&topic_name, 1).await.unwrap();
+    let partition_client = client
+        .partition_client(&topic_name, 1, PartitionClientBindMode::Strong)
+        .await
+        .unwrap();
     partition_client
         .produce(vec![], Compression::NoCompression)
         .await
@@ -219,7 +258,10 @@ async fn test_consume_empty() {
         .await
         .unwrap();
 
-    let partition_client = client.partition_client(&topic_name, 1).await.unwrap();
+    let partition_client = client
+        .partition_client(&topic_name, 1, PartitionClientBindMode::Strong)
+        .await
+        .unwrap();
     let (records, watermark) = partition_client
         .fetch_records(0, 1..10_000, 1_000)
         .await
@@ -243,7 +285,10 @@ async fn test_consume_offset_out_of_range() {
         .await
         .unwrap();
 
-    let partition_client = client.partition_client(&topic_name, 1).await.unwrap();
+    let partition_client = client
+        .partition_client(&topic_name, 1, PartitionClientBindMode::Strong)
+        .await
+        .unwrap();
     let record = record(b"");
     let offsets = partition_client
         .produce(vec![record], Compression::NoCompression)
@@ -259,6 +304,7 @@ async fn test_consume_offset_out_of_range() {
         err,
         ClientError::ServerError {
             protocol_error: ProtocolError::OffsetOutOfRange,
+            response: Some(ServerErrorResponse::PartitionFetchState { .. }),
             ..
         }
     );
@@ -283,7 +329,7 @@ async fn test_get_offset() {
         .unwrap();
 
     let partition_client = client
-        .partition_client(topic_name.clone(), 0)
+        .partition_client(topic_name.clone(), 0, PartitionClientBindMode::Strong)
         .await
         .unwrap();
 
@@ -346,7 +392,12 @@ async fn test_produce_consume_size_cutoff() {
         .await
         .unwrap();
 
-    let partition_client = Arc::new(client.partition_client(&topic_name, 0).await.unwrap());
+    let partition_client = Arc::new(
+        client
+            .partition_client(&topic_name, 0, PartitionClientBindMode::Strong)
+            .await
+            .unwrap(),
+    );
 
     let record_1 = large_record();
     let record_2 = large_record();
@@ -419,7 +470,10 @@ async fn test_consume_midbatch() {
         .await
         .unwrap();
 
-    let partition_client = client.partition_client(&topic_name, 0).await.unwrap();
+    let partition_client = client
+        .partition_client(&topic_name, 0, PartitionClientBindMode::Strong)
+        .await
+        .unwrap();
 
     // produce two records into a single batch
     let record_1 = record(b"x");
@@ -464,7 +518,10 @@ async fn test_delete_records() {
         .await
         .unwrap();
 
-    let partition_client = client.partition_client(&topic_name, 0).await.unwrap();
+    let partition_client = client
+        .partition_client(&topic_name, 0, PartitionClientBindMode::Strong)
+        .await
+        .unwrap();
 
     // produce the following record batches:
     // - record_1
@@ -509,6 +566,7 @@ async fn test_delete_records() {
         err,
         ClientError::ServerError {
             protocol_error: ProtocolError::OffsetOutOfRange,
+            response: Some(ServerErrorResponse::PartitionFetchState { .. }),
             ..
         }
     );
@@ -520,6 +578,7 @@ async fn test_delete_records() {
         err,
         ClientError::ServerError {
             protocol_error: ProtocolError::OffsetOutOfRange,
+            response: Some(ServerErrorResponse::PartitionFetchState { .. }),
             ..
         }
     );

--- a/tests/consumer.rs
+++ b/tests/consumer.rs
@@ -50,7 +50,7 @@ async fn test_stream_consumer_start_at_0() {
         .build();
 
     // Fetch first record
-    assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+    assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
 
     // No further records
     assert_stream_pending(&mut stream).await;
@@ -64,10 +64,10 @@ async fn test_stream_consumer_start_at_0() {
         .unwrap();
 
     // Get second record
-    assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+    assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
 
     // Get third record
-    assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+    assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
 
     // No further records
     assert_stream_pending(&mut stream).await;
@@ -110,7 +110,7 @@ async fn test_stream_consumer_start_at_1() {
 
     // Skips first record
     let (record_and_offset, _watermark) =
-        assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
     assert_eq!(record_and_offset.record, record_2);
 
     // No further records
@@ -188,7 +188,7 @@ async fn test_stream_consumer_start_at_earliest() {
 
     // Fetch first record
     let (record_and_offset, _) =
-        assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
     assert_eq!(record_and_offset.record, record_1);
 
     // No further records
@@ -201,7 +201,7 @@ async fn test_stream_consumer_start_at_earliest() {
 
     // Get second record
     let (record_and_offset, _) =
-        assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
     assert_eq!(record_and_offset.record, record_2);
 
     // No further records
@@ -246,7 +246,7 @@ async fn test_stream_consumer_start_at_earliest_empty() {
 
     // Get second record
     let (record_and_offset, _) =
-        assert_ok(timeout(Duration::from_millis(200), stream.next()).await);
+        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
     assert_eq!(record_and_offset.record, record);
 
     // No further records
@@ -293,7 +293,7 @@ async fn test_stream_consumer_start_at_earliest_after_deletion() {
 
     // First record skipped / deleted
     let (record_and_offset, _) =
-        assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
     assert_eq!(record_and_offset.record, record_2);
 
     // No further records
@@ -342,7 +342,7 @@ async fn test_stream_consumer_start_at_latest() {
 
     // Get second record
     let (record_and_offset, _) =
-        assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
     assert_eq!(record_and_offset.record, record_2);
 
     // No further records
@@ -386,7 +386,7 @@ async fn test_stream_consumer_start_at_latest_empty() {
 
     // Get second record
     let (record_and_offset, _) =
-        assert_ok(timeout(Duration::from_millis(100), stream.next()).await);
+        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
     assert_eq!(record_and_offset.record, record);
 
     // No further records

--- a/tests/consumer.rs
+++ b/tests/consumer.rs
@@ -9,7 +9,7 @@ use rskafka::{
     client::{
         consumer::{StartOffset, StreamConsumer, StreamConsumerBuilder},
         error::{Error, ProtocolError},
-        partition::Compression,
+        partition::{Compression, PartitionClientBindMode},
         ClientBuilder,
     },
     record::RecordAndOffset,
@@ -34,7 +34,12 @@ async fn test_stream_consumer_start_at_0() {
 
     let record = record(b"x");
 
-    let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
+    let partition_client = Arc::new(
+        client
+            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .await
+            .unwrap(),
+    );
     partition_client
         .produce(vec![record.clone()], Compression::NoCompression)
         .await
@@ -85,7 +90,12 @@ async fn test_stream_consumer_start_at_1() {
     let record_1 = record(b"x");
     let record_2 = record(b"y");
 
-    let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
+    let partition_client = Arc::new(
+        client
+            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .await
+            .unwrap(),
+    );
     partition_client
         .produce(
             vec![record_1.clone(), record_2.clone()],
@@ -121,7 +131,12 @@ async fn test_stream_consumer_offset_out_of_range() {
         .await
         .unwrap();
 
-    let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
+    let partition_client = Arc::new(
+        client
+            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .await
+            .unwrap(),
+    );
 
     let mut stream = StreamConsumerBuilder::new(partition_client, StartOffset::At(1)).build();
 
@@ -155,7 +170,12 @@ async fn test_stream_consumer_start_at_earliest() {
     let record_1 = record(b"x");
     let record_2 = record(b"y");
 
-    let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
+    let partition_client = Arc::new(
+        client
+            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .await
+            .unwrap(),
+    );
     partition_client
         .produce(vec![record_1.clone()], Compression::NoCompression)
         .await
@@ -204,7 +224,12 @@ async fn test_stream_consumer_start_at_earliest_empty() {
 
     let record = record(b"x");
 
-    let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
+    let partition_client = Arc::new(
+        client
+            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .await
+            .unwrap(),
+    );
 
     let mut stream =
         StreamConsumerBuilder::new(Arc::clone(&partition_client), StartOffset::Earliest)
@@ -245,7 +270,12 @@ async fn test_stream_consumer_start_at_earliest_after_deletion() {
     let record_1 = record(b"x");
     let record_2 = record(b"y");
 
-    let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
+    let partition_client = Arc::new(
+        client
+            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .await
+            .unwrap(),
+    );
     partition_client
         .produce(
             vec![record_1.clone(), record_2.clone()],
@@ -287,7 +317,12 @@ async fn test_stream_consumer_start_at_latest() {
     let record_1 = record(b"x");
     let record_2 = record(b"y");
 
-    let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
+    let partition_client = Arc::new(
+        client
+            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .await
+            .unwrap(),
+    );
     partition_client
         .produce(vec![record_1.clone()], Compression::NoCompression)
         .await
@@ -330,7 +365,12 @@ async fn test_stream_consumer_start_at_latest_empty() {
 
     let record = record(b"x");
 
-    let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
+    let partition_client = Arc::new(
+        client
+            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .await
+            .unwrap(),
+    );
 
     let mut stream = StreamConsumerBuilder::new(Arc::clone(&partition_client), StartOffset::Latest)
         .with_max_wait_ms(50)

--- a/tests/consumer.rs
+++ b/tests/consumer.rs
@@ -9,7 +9,7 @@ use rskafka::{
     client::{
         consumer::{StartOffset, StreamConsumer, StreamConsumerBuilder},
         error::{Error, ProtocolError},
-        partition::{Compression, PartitionClientBindMode},
+        partition::{Compression, UnknownTopicHandling},
         ClientBuilder,
     },
     record::RecordAndOffset,
@@ -36,7 +36,7 @@ async fn test_stream_consumer_start_at_0() {
 
     let partition_client = Arc::new(
         client
-            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .partition_client(&topic, 0, UnknownTopicHandling::Retry)
             .await
             .unwrap(),
     );
@@ -92,7 +92,7 @@ async fn test_stream_consumer_start_at_1() {
 
     let partition_client = Arc::new(
         client
-            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .partition_client(&topic, 0, UnknownTopicHandling::Retry)
             .await
             .unwrap(),
     );
@@ -133,7 +133,7 @@ async fn test_stream_consumer_offset_out_of_range() {
 
     let partition_client = Arc::new(
         client
-            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .partition_client(&topic, 0, UnknownTopicHandling::Retry)
             .await
             .unwrap(),
     );
@@ -172,7 +172,7 @@ async fn test_stream_consumer_start_at_earliest() {
 
     let partition_client = Arc::new(
         client
-            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .partition_client(&topic, 0, UnknownTopicHandling::Retry)
             .await
             .unwrap(),
     );
@@ -226,7 +226,7 @@ async fn test_stream_consumer_start_at_earliest_empty() {
 
     let partition_client = Arc::new(
         client
-            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .partition_client(&topic, 0, UnknownTopicHandling::Retry)
             .await
             .unwrap(),
     );
@@ -272,7 +272,7 @@ async fn test_stream_consumer_start_at_earliest_after_deletion() {
 
     let partition_client = Arc::new(
         client
-            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .partition_client(&topic, 0, UnknownTopicHandling::Retry)
             .await
             .unwrap(),
     );
@@ -319,7 +319,7 @@ async fn test_stream_consumer_start_at_latest() {
 
     let partition_client = Arc::new(
         client
-            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .partition_client(&topic, 0, UnknownTopicHandling::Retry)
             .await
             .unwrap(),
     );
@@ -367,7 +367,7 @@ async fn test_stream_consumer_start_at_latest_empty() {
 
     let partition_client = Arc::new(
         client
-            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .partition_client(&topic, 0, UnknownTopicHandling::Retry)
             .await
             .unwrap(),
     );

--- a/tests/produce_consume.rs
+++ b/tests/produce_consume.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use rskafka::{
     client::{
-        partition::{Compression, PartitionClient, PartitionClientBindMode},
+        partition::{Compression, PartitionClient, UnknownTopicHandling},
         ClientBuilder,
     },
     record::{Record, RecordAndOffset},
@@ -262,7 +262,7 @@ async fn assert_produce_consume<F1, G1, F2, G2>(
 
     let partition_client = Arc::new(
         client
-            .partition_client(topic_name.clone(), 1, PartitionClientBindMode::Strong)
+            .partition_client(topic_name.clone(), 1, UnknownTopicHandling::Retry)
             .await
             .unwrap(),
     );

--- a/tests/produce_consume.rs
+++ b/tests/produce_consume.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use rskafka::{
     client::{
-        partition::{Compression, PartitionClient},
+        partition::{Compression, PartitionClient, PartitionClientBindMode},
         ClientBuilder,
     },
     record::{Record, RecordAndOffset},
@@ -253,14 +253,16 @@ async fn assert_produce_consume<F1, G1, F2, G2>(
         .build()
         .await
         .unwrap();
+
     let controller_client = client.controller_client().unwrap();
     controller_client
         .create_topic(&topic_name, n_partitions, 1, 5_000)
         .await
         .unwrap();
+
     let partition_client = Arc::new(
         client
-            .partition_client(topic_name.clone(), 1)
+            .partition_client(topic_name.clone(), 1, PartitionClientBindMode::Strong)
             .await
             .unwrap(),
     );

--- a/tests/producer.rs
+++ b/tests/producer.rs
@@ -1,5 +1,6 @@
 use futures::{future::FusedFuture, pin_mut, FutureExt};
 use rskafka::client::{
+    partition::PartitionClientBindMode,
     producer::{aggregator::RecordAggregator, BatchProducerBuilder},
     ClientBuilder,
 };
@@ -25,7 +26,13 @@ async fn test_batch_producer() {
 
     let record = record(b"");
 
-    let partition_client = Arc::new(client.partition_client(&topic, 0).await.unwrap());
+    let partition_client = Arc::new(
+        client
+            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .await
+            .unwrap(),
+    );
+
     let producer = BatchProducerBuilder::new(partition_client)
         .with_linger(Duration::from_secs(5))
         .build(RecordAggregator::new(record.approximate_size() * 2 + 1));

--- a/tests/producer.rs
+++ b/tests/producer.rs
@@ -1,6 +1,6 @@
 use futures::{future::FusedFuture, pin_mut, FutureExt};
 use rskafka::client::{
-    partition::PartitionClientBindMode,
+    partition::UnknownTopicHandling,
     producer::{aggregator::RecordAggregator, BatchProducerBuilder},
     ClientBuilder,
 };
@@ -28,7 +28,7 @@ async fn test_batch_producer() {
 
     let partition_client = Arc::new(
         client
-            .partition_client(&topic, 0, PartitionClientBindMode::Strong)
+            .partition_client(&topic, 0, UnknownTopicHandling::Retry)
             .await
             .unwrap(),
     );


### PR DESCRIPTION
# 1. Protocol "Fix"
Redpanda seems to expect that we send a bit more data in the protocol header (kafka doesn't care), so let's make it happy.

# 2. Topic-auto-creation
Topic auto-creation should never have worked for our dev/ci Kafka/redpanda nodes. Let's disable it (this actually was caught by the test for the bind mode feature, see next point).

# 3. Bind mode to address "unknown topic or partition"
Let's face it: the protocol is a bit of a mess and some users (mostly
the ones that expect that partitions can be deleted) need to deal with
it, while for others we can make iron over it.

Closes #168.
Fixes #169.