### PR TITLE
test: improve testing config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,6 +207,7 @@ jobs:
       RUST_LOG: "trace"
       # Run integration tests
       TEST_INTEGRATION: 1
+      TEST_BROKER_IMPL: redpanda
       TEST_JAVA_INTEROPT: 1
       # Don't use the first node here since this is likely the controller and we want to ensure that we automatically
       # pick the controller for certain actions (e.g. topic creation) and don't just get lucky.
@@ -284,8 +285,7 @@ jobs:
       RUST_LOG: "trace"
       # Run integration tests
       TEST_INTEGRATION: 1
-      # Kafka support DeleteRecords
-      TEST_DELETE_RECORDS: 1
+      TEST_BROKER_IMPL: kafka
       TEST_JAVA_INTEROPT: 1
       # Don't use the first node here since this is likely the controller and we want to ensure that we automatically
       # pick the controller for certain actions (e.g. topic creation) and don't just get lucky.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $ docker-compose -f docker-compose-redpanda.yml up
 in one session, and then run:
 
 ```console
-$ TEST_INTEGRATION=1 KAFKA_CONNECT=0.0.0.0:9011 cargo test
+$ TEST_INTEGRATION=1 TEST_BROKER_IMPL=redpanda KAFKA_CONNECT=0.0.0.0:9011 cargo test
 ```
 
 in another session.
@@ -131,7 +131,7 @@ $ docker-compose -f docker-compose-kafka.yml up
 in one session, and then run:
 
 ```console
-$ TEST_INTEGRATION=1 TEST_DELETE_RECORDS=1 KAFKA_CONNECT=localhost:9011 cargo test
+$ TEST_INTEGRATION=1 TEST_BROKER_IMPL=kafka KAFKA_CONNECT=localhost:9011 cargo test
 ```
 
 in another session. Note that Apache Kafka supports a different set of features then redpanda, so we pass other
@@ -231,14 +231,14 @@ execution that hooks right into the place where it is about to exit:
 Install [cargo-criterion], make sure you have some Kafka cluster running, and then you can run all benchmarks with:
 
 ```console
-$ TEST_INTEGRATION=1 KAFKA_CONNECT=localhost:9011 cargo criterion --all-features
+$ TEST_INTEGRATION=1 TEST_BROKER_IMPL=kafka KAFKA_CONNECT=localhost:9011 cargo criterion --all-features
 ```
 
 If you find a benchmark that is too slow, you can may want to profile it. Get [cargo-with], and [perf], then run (here
 for the `parallel/rskafka` benchmark):
 
 ```console
-$ TEST_INTEGRATION=1 KAFKA_CONNECT=localhost:9011 cargo with 'perf record --call-graph dwarf -- {bin}' -- \
+$ TEST_INTEGRATION=1 TEST_BROKER_IMPL=kafka KAFKA_CONNECT=localhost:9011 cargo with 'perf record --call-graph dwarf -- {bin}' -- \
     bench --all-features --bench write_throughput -- \
     --bench --noplot parallel/rskafka
 ```

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -16,16 +16,22 @@ use test_helpers::{maybe_start_logging, now, random_topic_name, record};
 async fn test_plain() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
-    ClientBuilder::new(connection).build().await.unwrap();
+    let test_cfg = maybe_skip_kafka_integration!();
+    ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
 async fn test_topic_crud() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let test_cfg = maybe_skip_kafka_integration!();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
     let topics = client.list_topics().await.unwrap();
 
@@ -77,10 +83,13 @@ async fn test_topic_crud() {
 async fn test_partition_client() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
+    let test_cfg = maybe_skip_kafka_integration!();
     let topic_name = random_topic_name();
 
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
 
     let controller_client = client.controller_client().unwrap();
     controller_client
@@ -100,10 +109,13 @@ async fn test_partition_client() {
 async fn test_non_existing_partition() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
+    let test_cfg = maybe_skip_kafka_integration!();
     let topic_name = random_topic_name();
 
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
 
     // do NOT create the topic
 
@@ -167,8 +179,8 @@ async fn test_tls() {
         .with_single_cert(vec![producer_root], private_key)
         .unwrap();
 
-    let connection = maybe_skip_kafka_integration!();
-    ClientBuilder::new(connection)
+    let test_cfg = maybe_skip_kafka_integration!();
+    ClientBuilder::new(test_cfg.bootstrap_brokers)
         .tls_config(Arc::new(config))
         .build()
         .await
@@ -180,14 +192,11 @@ async fn test_tls() {
 async fn test_socks5() {
     maybe_start_logging();
 
-    // e.g. "my-connection-kafka-bootstrap:9092"
-    let connection = maybe_skip_kafka_integration!();
-    // e.g. "localhost:1080"
-    let proxy = maybe_skip_SOCKS_PROXY!();
+    let test_cfg = maybe_skip_kafka_integration!(socks5);
     let topic_name = random_topic_name();
 
-    let client = ClientBuilder::new(connection)
-        .socks5_proxy(proxy)
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .socks5_proxy(test_cfg.socks5_proxy.unwrap())
         .build()
         .await
         .unwrap();
@@ -222,11 +231,14 @@ async fn test_socks5() {
 async fn test_produce_empty() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
+    let test_cfg = maybe_skip_kafka_integration!();
     let topic_name = random_topic_name();
     let n_partitions = 2;
 
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
     controller_client
         .create_topic(&topic_name, n_partitions, 1, 5_000)
@@ -247,11 +259,14 @@ async fn test_produce_empty() {
 async fn test_consume_empty() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
+    let test_cfg = maybe_skip_kafka_integration!();
     let topic_name = random_topic_name();
     let n_partitions = 2;
 
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
     controller_client
         .create_topic(&topic_name, n_partitions, 1, 5_000)
@@ -274,11 +289,14 @@ async fn test_consume_empty() {
 async fn test_consume_offset_out_of_range() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
+    let test_cfg = maybe_skip_kafka_integration!();
     let topic_name = random_topic_name();
     let n_partitions = 2;
 
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
     controller_client
         .create_topic(&topic_name, n_partitions, 1, 5_000)
@@ -314,11 +332,11 @@ async fn test_consume_offset_out_of_range() {
 async fn test_get_offset() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
+    let test_cfg = maybe_skip_kafka_integration!();
     let topic_name = random_topic_name();
     let n_partitions = 1;
 
-    let client = ClientBuilder::new(connection.clone())
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers.clone())
         .build()
         .await
         .unwrap();
@@ -382,10 +400,13 @@ async fn test_get_offset() {
 async fn test_produce_consume_size_cutoff() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
+    let test_cfg = maybe_skip_kafka_integration!();
     let topic_name = random_topic_name();
 
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
     controller_client
         .create_topic(&topic_name, 1, 1, 5_000)
@@ -460,10 +481,13 @@ async fn test_produce_consume_size_cutoff() {
 async fn test_consume_midbatch() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
+    let test_cfg = maybe_skip_kafka_integration!();
     let topic_name = random_topic_name();
 
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
     controller_client
         .create_topic(&topic_name, 1, 1, 5_000)
@@ -508,10 +532,13 @@ async fn test_consume_midbatch() {
 async fn test_delete_records() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
+    let test_cfg = maybe_skip_kafka_integration!(delete);
     let topic_name = random_topic_name();
 
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
     controller_client
         .create_topic(&topic_name, 1, 1, 5_000)
@@ -555,7 +582,10 @@ async fn test_delete_records() {
     let offset_4 = offsets[0];
 
     // delete from the middle of the 2nd batch
-    maybe_skip_delete!(partition_client, offset_3);
+    partition_client
+        .delete_records(offset_3, 1_000)
+        .await
+        .unwrap();
 
     // fetching data before the record fails
     let err = partition_client

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -10,7 +10,7 @@ use rskafka::{
 use std::{collections::BTreeMap, str::FromStr, sync::Arc, time::Duration};
 
 mod test_helpers;
-use test_helpers::{maybe_start_logging, now, random_topic_name, record};
+use test_helpers::{maybe_start_logging, now, random_topic_name, record, TEST_TIMEOUT};
 
 #[tokio::test]
 async fn test_plain() {
@@ -52,7 +52,7 @@ async fn test_topic_crud() {
         .unwrap();
 
     // might take a while to converge
-    tokio::time::timeout(Duration::from_millis(1_000), async {
+    tokio::time::timeout(TEST_TIMEOUT, async {
         loop {
             let topics = client.list_topics().await.unwrap();
             let topic = topics.iter().find(|t| t.name == new_topic);
@@ -119,6 +119,7 @@ async fn test_non_existing_partition() {
 
     // do NOT create the topic
 
+    // short timeout, should just check that we will never finish
     tokio::time::timeout(Duration::from_millis(100), async {
         client
             .partition_client(topic_name.clone(), 0, UnknownTopicHandling::Retry)

--- a/tests/consumer.rs
+++ b/tests/consumer.rs
@@ -14,7 +14,7 @@ use rskafka::{
     },
     record::RecordAndOffset,
 };
-use test_helpers::{maybe_start_logging, random_topic_name, record};
+use test_helpers::{maybe_start_logging, random_topic_name, record, TEST_TIMEOUT};
 
 mod test_helpers;
 
@@ -53,7 +53,7 @@ async fn test_stream_consumer_start_at_0() {
         .build();
 
     // Fetch first record
-    assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
+    assert_ok(timeout(TEST_TIMEOUT, stream.next()).await);
 
     // No further records
     assert_stream_pending(&mut stream).await;
@@ -67,10 +67,10 @@ async fn test_stream_consumer_start_at_0() {
         .unwrap();
 
     // Get second record
-    assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
+    assert_ok(timeout(TEST_TIMEOUT, stream.next()).await);
 
     // Get third record
-    assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
+    assert_ok(timeout(TEST_TIMEOUT, stream.next()).await);
 
     // No further records
     assert_stream_pending(&mut stream).await;
@@ -115,8 +115,7 @@ async fn test_stream_consumer_start_at_1() {
         .build();
 
     // Skips first record
-    let (record_and_offset, _watermark) =
-        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
+    let (record_and_offset, _watermark) = assert_ok(timeout(TEST_TIMEOUT, stream.next()).await);
     assert_eq!(record_and_offset.record, record_2);
 
     // No further records
@@ -199,8 +198,7 @@ async fn test_stream_consumer_start_at_earliest() {
             .build();
 
     // Fetch first record
-    let (record_and_offset, _) =
-        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
+    let (record_and_offset, _) = assert_ok(timeout(TEST_TIMEOUT, stream.next()).await);
     assert_eq!(record_and_offset.record, record_1);
 
     // No further records
@@ -212,8 +210,7 @@ async fn test_stream_consumer_start_at_earliest() {
         .unwrap();
 
     // Get second record
-    let (record_and_offset, _) =
-        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
+    let (record_and_offset, _) = assert_ok(timeout(TEST_TIMEOUT, stream.next()).await);
     assert_eq!(record_and_offset.record, record_2);
 
     // No further records
@@ -260,8 +257,7 @@ async fn test_stream_consumer_start_at_earliest_empty() {
         .unwrap();
 
     // Get second record
-    let (record_and_offset, _) =
-        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
+    let (record_and_offset, _) = assert_ok(timeout(TEST_TIMEOUT, stream.next()).await);
     assert_eq!(record_and_offset.record, record);
 
     // No further records
@@ -315,8 +311,7 @@ async fn test_stream_consumer_start_at_earliest_after_deletion() {
             .build();
 
     // First record skipped / deleted
-    let (record_and_offset, _) =
-        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
+    let (record_and_offset, _) = assert_ok(timeout(TEST_TIMEOUT, stream.next()).await);
     assert_eq!(record_and_offset.record, record_2);
 
     // No further records
@@ -367,8 +362,7 @@ async fn test_stream_consumer_start_at_latest() {
         .unwrap();
 
     // Get second record
-    let (record_and_offset, _) =
-        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
+    let (record_and_offset, _) = assert_ok(timeout(TEST_TIMEOUT, stream.next()).await);
     assert_eq!(record_and_offset.record, record_2);
 
     // No further records
@@ -414,8 +408,7 @@ async fn test_stream_consumer_start_at_latest_empty() {
         .unwrap();
 
     // Get second record
-    let (record_and_offset, _) =
-        assert_ok(timeout(Duration::from_millis(1_000), stream.next()).await);
+    let (record_and_offset, _) = assert_ok(timeout(TEST_TIMEOUT, stream.next()).await);
     assert_eq!(record_and_offset.record, record);
 
     // No further records

--- a/tests/consumer.rs
+++ b/tests/consumer.rs
@@ -22,8 +22,11 @@ mod test_helpers;
 async fn test_stream_consumer_start_at_0() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let test_cfg = maybe_skip_kafka_integration!();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
 
     let topic = random_topic_name();
@@ -77,8 +80,11 @@ async fn test_stream_consumer_start_at_0() {
 async fn test_stream_consumer_start_at_1() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let test_cfg = maybe_skip_kafka_integration!();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
 
     let topic = random_topic_name();
@@ -121,8 +127,11 @@ async fn test_stream_consumer_start_at_1() {
 async fn test_stream_consumer_offset_out_of_range() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let test_cfg = maybe_skip_kafka_integration!();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
 
     let topic = random_topic_name();
@@ -157,8 +166,11 @@ async fn test_stream_consumer_offset_out_of_range() {
 async fn test_stream_consumer_start_at_earliest() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let test_cfg = maybe_skip_kafka_integration!();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
 
     let topic = random_topic_name();
@@ -212,8 +224,11 @@ async fn test_stream_consumer_start_at_earliest() {
 async fn test_stream_consumer_start_at_earliest_empty() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let test_cfg = maybe_skip_kafka_integration!();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
 
     let topic = random_topic_name();
@@ -257,8 +272,16 @@ async fn test_stream_consumer_start_at_earliest_empty() {
 async fn test_stream_consumer_start_at_earliest_after_deletion() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let test_cfg = maybe_skip_kafka_integration!(delete);
+    if !test_cfg.broker_impl.supports_deletes() {
+        println!("Skipping due to missing delete support");
+        return;
+    }
+
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
 
     let topic = random_topic_name();
@@ -284,7 +307,7 @@ async fn test_stream_consumer_start_at_earliest_after_deletion() {
         .await
         .unwrap();
 
-    maybe_skip_delete!(partition_client, 1);
+    partition_client.delete_records(1, 1_000).await.unwrap();
 
     let mut stream =
         StreamConsumerBuilder::new(Arc::clone(&partition_client), StartOffset::Earliest)
@@ -304,8 +327,11 @@ async fn test_stream_consumer_start_at_earliest_after_deletion() {
 async fn test_stream_consumer_start_at_latest() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let test_cfg = maybe_skip_kafka_integration!();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
 
     let topic = random_topic_name();
@@ -353,8 +379,11 @@ async fn test_stream_consumer_start_at_latest() {
 async fn test_stream_consumer_start_at_latest_empty() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let test_cfg = maybe_skip_kafka_integration!();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
 
     let topic = random_topic_name();

--- a/tests/produce_consume.rs
+++ b/tests/produce_consume.rs
@@ -245,11 +245,11 @@ async fn assert_produce_consume<F1, G1, F2, G2>(
 {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
+    let test_cfg = maybe_skip_kafka_integration!();
     let topic_name = random_topic_name();
     let n_partitions = 2;
 
-    let client = ClientBuilder::new(connection.clone())
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers.clone())
         .build()
         .await
         .unwrap();
@@ -306,7 +306,7 @@ async fn assert_produce_consume<F1, G1, F2, G2>(
     offsets.append(
         &mut f_produce(
             Arc::clone(&partition_client),
-            connection.clone(),
+            test_cfg.bootstrap_brokers.clone(),
             topic_name.clone(),
             1,
             vec![record_1.clone(), record_2.clone()],
@@ -317,7 +317,7 @@ async fn assert_produce_consume<F1, G1, F2, G2>(
     offsets.append(
         &mut f_produce(
             Arc::clone(&partition_client),
-            connection.clone(),
+            test_cfg.bootstrap_brokers.clone(),
             topic_name.clone(),
             1,
             vec![record_3.clone()],
@@ -331,7 +331,14 @@ async fn assert_produce_consume<F1, G1, F2, G2>(
     assert_ne!(offsets[2], offsets[0]);
 
     // consume
-    let actual = f_consume(partition_client, connection, topic_name, 1, 3).await;
+    let actual = f_consume(
+        partition_client,
+        test_cfg.bootstrap_brokers,
+        topic_name,
+        1,
+        3,
+    )
+    .await;
     let expected: Vec<_> = offsets
         .into_iter()
         .zip([record_1, record_2, record_3])

--- a/tests/producer.rs
+++ b/tests/producer.rs
@@ -14,8 +14,11 @@ use test_helpers::{maybe_start_logging, random_topic_name, record};
 async fn test_batch_producer() {
     maybe_start_logging();
 
-    let connection = maybe_skip_kafka_integration!();
-    let client = ClientBuilder::new(connection).build().await.unwrap();
+    let test_cfg = maybe_skip_kafka_integration!();
+    let client = ClientBuilder::new(test_cfg.bootstrap_brokers)
+        .build()
+        .await
+        .unwrap();
     let controller_client = client.controller_client().unwrap();
 
     let topic = random_topic_name();

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -3,93 +3,147 @@ use rskafka::record::Record;
 use std::collections::BTreeMap;
 use time::OffsetDateTime;
 
-/// Get the testing Kafka connection string or return current scope.
+/// Environment variable to configure if integration tests should be run.
 ///
-/// If `TEST_INTEGRATION` and `KAFKA_CONNECT` are set, return the Kafka connection URL to the
-/// caller.
+/// Accepts a boolean.
+pub const ENV_TEST_INTEGRATION: &str = "TEST_INTEGRATION";
+
+/// Environment variable that contains the list of bootstrap brokers.
+pub const ENV_KAFKA_CONNECT: &str = "KAFKA_CONNECT";
+
+/// Environment variable that determines which broker implementation we use.
+pub const ENV_TEST_BROKER_IMPL: &str = "TEST_BROKER_IMPL";
+
+/// Environment variable that contains the connection string for a SOCKS5 proxy that can be used for testing.
+pub const ENV_SOCKS5_PROXY: &str = "SOCKS5_PROXY";
+
+/// Broker implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrokerImpl {
+    Kafka,
+    Redpanda,
+}
+
+impl BrokerImpl {
+    #[allow(dead_code)]
+    pub fn supports_deletes(&self) -> bool {
+        match self {
+            BrokerImpl::Kafka => true,
+            // See https://github.com/redpanda-data/redpanda/issues/2648
+            BrokerImpl::Redpanda => false,
+        }
+    }
+}
+
+/// Test config.
+#[derive(Debug)]
+pub struct TestConfig {
+    pub bootstrap_brokers: Vec<String>,
+    pub broker_impl: BrokerImpl,
+    pub socks5_proxy: Option<String>,
+}
+
+impl TestConfig {
+    /// Get test config from environment.
+    pub fn from_env() -> Option<Self> {
+        dotenvy::dotenv().ok();
+
+        match std::env::var(ENV_TEST_INTEGRATION)
+            .ok()
+            .map(|s| parse_as_bool(&s))
+        {
+            None | Some(Ok(false)) => {
+                return None;
+            }
+            Some(Ok(true)) => {}
+            Some(Err(s)) => {
+                panic!("Invalid value for {ENV_TEST_INTEGRATION}: {s}")
+            }
+        }
+
+        let bootstrap_brokers = std::env::var(ENV_KAFKA_CONNECT)
+            .ok()
+            .unwrap_or_else(|| panic!("{ENV_KAFKA_CONNECT} not set, please read README"))
+            .split(',')
+            .map(|s| s.trim().to_owned())
+            .collect();
+
+        let broker_impl = std::env::var(ENV_TEST_BROKER_IMPL)
+            .ok()
+            .unwrap_or_else(|| panic!("{ENV_TEST_BROKER_IMPL} is required to determine the broker implementation (e.g. kafka, redpanda)"))
+            .to_lowercase();
+        let broker_impl = match broker_impl.as_str() {
+            "kafka" => BrokerImpl::Kafka,
+            "redpanda" => BrokerImpl::Redpanda,
+            other => panic!("Invalid {ENV_TEST_BROKER_IMPL}: {other}"),
+        };
+
+        let socks5_proxy = std::env::var(ENV_SOCKS5_PROXY).ok();
+
+        Some(Self {
+            bootstrap_brokers,
+            broker_impl,
+            socks5_proxy,
+        })
+    }
+}
+
+/// Parse string as boolean variable.
+fn parse_as_bool(s: &str) -> Result<bool, String> {
+    let s_lower = s.to_lowercase();
+
+    match s_lower.as_str() {
+        "0" | "false" | "f" | "no" | "n" => Ok(false),
+        "1" | "true" | "t" | "yes" | "y" => Ok(true),
+        _ => Err(s.to_owned()),
+    }
+}
+
+/// Get [`TestConfig`] or exit test (by returning).
 ///
-/// If `TEST_INTEGRATION` is set but `KAFKA_CONNECT` is not set, fail the tests and provide
-/// guidance for setting `KAFKA_CONNECTION`.
+/// Takes an optional list of capabilities that are needed to run the test. These are:
 ///
-/// If `TEST_INTEGRATION` is not set, skip the calling test by returning early.
+/// - `delete`: the broker implementation must support deletes
+/// - `socks5`: a SOCKS5 proxy is available for tests
 #[macro_export]
 macro_rules! maybe_skip_kafka_integration {
     () => {{
-        use std::env;
-        dotenvy::dotenv().ok();
-
-        match (
-            env::var("TEST_INTEGRATION").is_ok(),
-            env::var("KAFKA_CONNECT").ok(),
-        ) {
-            (true, Some(kafka_connection)) => {
-                let kafka_connection: Vec<String> =
-                    kafka_connection.split(",").map(|s| s.to_owned()).collect();
-                kafka_connection
-            }
-            (true, None) => {
-                panic!(
-                    "TEST_INTEGRATION is set which requires running integration tests, but \
-                    KAFKA_CONNECT is not set. Please run Kafka or Redpanda then \
-                    set KAFKA_CONNECT as directed in README.md."
-                )
-            }
-            (false, Some(_)) => {
-                eprintln!("skipping Kafka integration tests - set TEST_INTEGRATION to run");
-                return;
-            }
-            (false, None) => {
+        match test_helpers::TestConfig::from_env() {
+            Some(cfg) => cfg,
+            None => {
                 eprintln!(
-                    "skipping Kafka integration tests - set TEST_INTEGRATION and KAFKA_CONNECT to \
-                    run"
+                    "skipping Kafka integration tests - set {} to run",
+                    test_helpers::ENV_KAFKA_CONNECT
                 );
                 return;
             }
         }
     }};
-}
-
-/// Performs delete operation using.
-///
-/// This is skipped (via `return`) if the broker returns `NoVersionMatch`, except when the `TEST_DELETE_RECORDS`
-/// environment variable is set.
-///
-/// This is helpful because Redpanda does not support deletes yet, see
-/// <https://github.com/redpanda-data/redpanda/issues/1016> but we also don not want to skip these test unconditionally.
-#[macro_export]
-macro_rules! maybe_skip_delete {
-    ($partition_client:ident, $offset:expr) => {
-        match $partition_client.delete_records($offset, 1_000).await {
-            Ok(()) => {}
-            Err(rskafka::client::error::Error::Request(
-                rskafka::client::error::RequestError::NoVersionMatch { .. },
-            )) if std::env::var("TEST_DELETE_RECORDS").is_err() => {
-                println!("Skip test_delete_records");
-                return;
-            }
-            Err(e) => panic!("Cannot delete: {e}"),
-        }
+    ($cap:ident) => {
+        $crate::maybe_skip_kafka_integration!($cap,)
     };
-}
-
-/// Get the Socks Proxy environment variable.
-///
-/// If `SOCKS_PROXY` is not set, fail the tests and provide
-/// guidance for setting `SOCKS_PROXY`.
-#[macro_export]
-macro_rules! maybe_skip_SOCKS_PROXY {
-    () => {{
-        use std::env;
-        dotenvy::dotenv().ok();
-
-        match (env::var("SOCKS_PROXY").ok()) {
-            Some(proxy) => proxy,
-            _ => {
-                eprintln!("skipping integration tests with Proxy - set SOCKS_PROXY to run");
-                return;
-            }
+    ($cap:ident, $($other:ident),*,) => {
+        $crate::maybe_skip_kafka_integration!($cap, $($other:ident),*)
+    };
+    (delete, $($other:ident),*) => {{
+        let cfg = $crate::maybe_skip_kafka_integration!($($other),*);
+        if !cfg.broker_impl.supports_deletes() {
+            eprintln!("Skipping due to missing delete support");
+            return;
         }
+        cfg
     }};
+    (socks5, $($other:ident),*) => {{
+        let cfg = $crate::maybe_skip_kafka_integration!($($other),*);
+        if cfg.socks5_proxy.is_none() {
+            eprintln!("skipping integration tests with Proxy - set {} to run", test_helpers::ENV_SOCKS5_PROXY);
+            return;
+        }
+        cfg
+    }};
+    ($cap:ident, $($other:ident),*) => {
+        compile_error!(concat!("invalid capability: ", stringify!($cap)))
+    };
 }
 
 /// Generated random topic name for testing.

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -1,7 +1,11 @@
 use parking_lot::Once;
 use rskafka::record::Record;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::Duration};
 use time::OffsetDateTime;
+
+/// Sensible test timeout.
+#[allow(dead_code)]
+pub const TEST_TIMEOUT: Duration = Duration::from_secs(4);
 
 /// Environment variable to configure if integration tests should be run.
 ///


### PR DESCRIPTION
Instead of having X different macros and control flow exists, let's have
one mechanism to read env variables and decide if a test shall run or
not.

This also moves the "which broker implementation supports which features"
from a bunch of environment variables into a nice enum. This will
greatly help when we expand the set of admit APIs, see #157 for example.
