### PR TITLE
build: remove fuzz target from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,6 @@ harness = false
 [workspace]
 members = [
     ".",
-    "fuzz",
 ]
 
 [profile.bench]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,6 +14,10 @@ pin-project-lite = "0.2"
 rskafka = { path = "..", features = ["unstable-fuzzing"] }
 tokio = { version = "1.14", default-features = false, features = ["io-util", "rt"] }
 
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
 [[bin]]
 name = "protocol_reader"
 path = "fuzz_targets/protocol_reader.rs"


### PR DESCRIPTION
Removes the fuzz target from the workspace, this fixes #174.

This is actually the default setup when you `cargo fuzz init`:

```rust
[package]
name = "blah-fuzz"
version = "0.0.0"
authors = ["Automatically generated"]
publish = false
edition = "2018"

[package.metadata]
cargo-fuzz = true

[dependencies]
libfuzzer-sys = "0.4"

[dependencies.blah]
path = ".."

# Prevent this from interfering with workspaces
[workspace]
members = ["."]

[[bin]]
name = "fuzz_target_1"
path = "fuzz_targets/fuzz_target_1.rs"
test = false
doc = false
```

Running `cargo fuzz ...` still works as usual, and that's what [CI does](https://github.com/influxdata/rskafka/blob/9b85cb2aa782cce5fe1fdddcd033df01a29ae31c/.circleci/config.yml#L437-L440) so this should not cause any problems.

---

* build: remove fuzz target from workspace (9b85cb2)

      This prevents the fuzz target from being run accidentally / run when compiled
      without instrumentation.