### PR TITLE
ci: update fuzz job scheduling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,14 +469,11 @@ workflows:
       - build-fuzz
       - doc
 
-  # Run fuzzers every 30mins
+  # Run fuzzers based on a project-wide trigger
   fuzz:
-    triggers:
-      - schedule:
-          cron: "0,30 * * * *"
-          filters:
-            branches:
-              only:
-                - main
+    when:
+      and:
+        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - equal: ["fuzz", << pipeline.schedule.name >>]
     jobs:
       - run-fuzz


### PR DESCRIPTION
CircleCI phases out the currently used mechanism, so we need to migrate it to use project-wide triggers.
