### PR TITLE
refactor: remove interior mutable from `Messenger::version_ranges`

### DIFF
--- a/fuzz/fuzz_targets/protocol_reader.rs
+++ b/fuzz/fuzz_targets/protocol_reader.rs
@@ -136,7 +136,7 @@ where
         let transport = MockTransport::new(transport_data);
 
         // setup messenger
-        let messenger = Messenger::new(transport, message_size, Arc::from(DEFAULT_CLIENT_ID));
+        let mut messenger = Messenger::new(transport, message_size, Arc::from(DEFAULT_CLIENT_ID));
         messenger.override_version_ranges(HashMap::from([(
             api_key,
             ApiVersionRange::new(api_version, api_version),

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -122,13 +122,9 @@ impl ConnectionHandler for BrokerRepresentation {
                 error,
             })?;
 
-        let messenger = Arc::new(Messenger::new(
-            BufStream::new(transport),
-            max_message_size,
-            client_id,
-        ));
+        let mut messenger = Messenger::new(BufStream::new(transport), max_message_size, client_id);
         messenger.sync_versions().await?;
-        Ok(messenger)
+        Ok(Arc::new(messenger))
     }
 }
 


### PR DESCRIPTION
Small clean-up before I start to work on #182.
