### PR TITLE
fix: (potential) metadata cache invalidation race

### DIFF
--- a/src/client/controller.rs
+++ b/src/client/controller.rs
@@ -99,7 +99,7 @@ impl ControllerClient {
     /// Retrieve the broker ID of the controller
     async fn get_controller_id(&self) -> Result<i32> {
         // Request an uncached, fresh copy of the metadata.
-        let metadata = self
+        let (metadata, _gen) = self
             .brokers
             .request_metadata(MetadataLookupMode::ArbitraryBroker, Some(vec![]))
             .await?;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -152,7 +152,7 @@ impl Client {
         //
         // Because this is an unconstrained metadata request (all topics) it
         // will update the cached metadata entry.
-        let response = self
+        let (response, _gen) = self
             .brokers
             .request_metadata(MetadataLookupMode::ArbitraryBroker, None)
             .await?;


### PR DESCRIPTION
Under certain conditions it MAY happen that metadata cache invalidation races, e.g.:

| Thread 1     | Thread 2     |
| ------------ | ------------ |
| get metadata |              |
|              | get metadata |
| invalidate   |              |
| get metadata |              |
|              | invalidate   |

Here the 2nd invalidation is unnecessary. It's not a correctness issue, but we throw away cached data that is perfectly fine.

To work around this, we now track a "generation" for data that we get from the metadata cache and check this during invalidation requests.

Ref #62. (not closing, need to do the same for the broker connection cache)
