### PR TITLE
feat: add wasi support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,34 +33,40 @@ rand = "0.8"
 rustls = { version = "0.20", optional = true }
 snap = { version = "1", optional = true }
 thiserror = "1.0"
-tokio = { version = "1.19", default-features = false, features = ["io-util", "net", "rt", "sync", "time", "macros"] }
 tokio-rustls = { version = "0.23", optional = true }
 tracing = "0.1"
 zstd = { version = "0.10", optional = true }
+
+[target.'cfg(not(target_os="wasi"))'.dependencies]
+tokio = { version = "1.19", default-features = false, features = ["io-util", "net", "rt", "sync", "time", "macros"] }
+
+[target.'cfg(target_os="wasi")'.dependencies]
+tokio_wasi = { version = "1.21", default-features = false, features = ["io-util", "net", "rt", "sync", "time", "macros"] }
+
 
 [dev-dependencies]
 assert_matches = "1.5"
 criterion = { version = "0.3", features = ["async_tokio"] }
 dotenvy = "0.15.1"
 futures = "0.3"
-j4rs = "0.13"
 once_cell = "1.9"
-procspawn = "0.10"
-proptest = "1"
-proptest-derive = "0.3"
 rustls-pemfile = "1.0"
-rdkafka = { version = "0.28", default-features = false, features = ["libz", "tokio", "zstd"] }
-tokio = { version = "1.14", features = ["macros", "rt-multi-thread"] }
 tracing-log = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.0", features = ["v4"] }
 
+[target.'cfg(not(target_os="wasi"))'.dev-dependencies]
+j4rs = "0.13"
+procspawn = "0.10"
+proptest = "1"
+proptest-derive = "0.3"
+rdkafka = { version = "0.28", default-features = false, features = ["libz", "tokio", "zstd"] }
+tokio = { version = "1.14", features = ["macros", "rt-multi-thread"] }
+
 [features]
 default = [
     "compression-gzip",
-    "compression-lz4",
     "compression-snappy",
-    "compression-zstd",
 ]
 
 full = [


### PR DESCRIPTION
Signed-off-by: Tricster <mediosrity@gmail.com>

Hi!
This pr will make `rskafka` work on WASI, which means it can be compiled into WebAssembly and executed by WASM runtimes like [WasmEdge](https://github.com/WasmEdge/WasmEdge).
The only change is to replace `tokio` with `tokio_wasi`.
Note that "compression-lz4" and "compression-zstd" are removed from default features because `lz4` and `zstd` are not supported on wasi yet.

- [x] I've read the contributing section of the project [CONTRIBUTING.md](https://github.com/influxdata/rskafka/blob/main/CONTRIBUTING.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
