### PR TITLE
refactor: Clientbuilder accept backoffconfig

### DIFF
--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -6,7 +6,7 @@ use tracing::info;
 /// Exponential backoff with jitter
 ///
 /// See <https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/>
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct BackoffConfig {
     pub init_backoff: Duration,
     pub max_backoff: Duration,

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -6,7 +6,8 @@ use tracing::info;
 /// Exponential backoff with jitter
 ///
 /// See <https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/>
-#[derive(Debug, Clone, Copy)]
+#[allow(missing_copy_implementations)]
+#[derive(Debug, Clone)]
 pub struct BackoffConfig {
     pub init_backoff: Duration,
     pub max_backoff: Duration,

--- a/src/client/controller.rs
+++ b/src/client/controller.rs
@@ -34,10 +34,13 @@ pub struct ControllerClient {
 }
 
 impl ControllerClient {
-    pub(super) fn new(brokers: Arc<BrokerConnector>) -> Self {
+    pub(super) fn new(
+        brokers: Arc<BrokerConnector>,
+        backoff_config: Option<BackoffConfig>,
+    ) -> Self {
         Self {
             brokers,
-            backoff_config: Default::default(),
+            backoff_config: backoff_config.unwrap_or_default(),
             current_broker: Mutex::new((None, BrokerCacheGeneration::START)),
         }
     }

--- a/src/client/controller.rs
+++ b/src/client/controller.rs
@@ -36,11 +36,11 @@ pub struct ControllerClient {
 impl ControllerClient {
     pub(super) fn new(
         brokers: Arc<BrokerConnector>,
-        backoff_config: Option<BackoffConfig>,
+        backoff_config: BackoffConfig,
     ) -> Self {
         Self {
             brokers,
-            backoff_config: backoff_config.unwrap_or_default(),
+            backoff_config,
             current_broker: Mutex::new((None, BrokerCacheGeneration::START)),
         }
     }

--- a/src/client/controller.rs
+++ b/src/client/controller.rs
@@ -27,14 +27,14 @@ use super::error::RequestContext;
 pub struct ControllerClient {
     brokers: Arc<BrokerConnector>,
 
-    backoff_config: BackoffConfig,
+    backoff_config: Arc<BackoffConfig>,
 
     /// Current broker connection if any
     current_broker: Mutex<(Option<BrokerConnection>, BrokerCacheGeneration)>,
 }
 
 impl ControllerClient {
-    pub(super) fn new(brokers: Arc<BrokerConnector>, backoff_config: BackoffConfig) -> Self {
+    pub(super) fn new(brokers: Arc<BrokerConnector>, backoff_config: Arc<BackoffConfig>) -> Self {
         Self {
             brokers,
             backoff_config,

--- a/src/client/controller.rs
+++ b/src/client/controller.rs
@@ -34,10 +34,7 @@ pub struct ControllerClient {
 }
 
 impl ControllerClient {
-    pub(super) fn new(
-        brokers: Arc<BrokerConnector>,
-        backoff_config: BackoffConfig
-    ) -> Self {
+    pub(super) fn new(brokers: Arc<BrokerConnector>, backoff_config: BackoffConfig) -> Self {
         Self {
             brokers,
             backoff_config,

--- a/src/client/controller.rs
+++ b/src/client/controller.rs
@@ -36,7 +36,7 @@ pub struct ControllerClient {
 impl ControllerClient {
     pub(super) fn new(
         brokers: Arc<BrokerConnector>,
-        backoff_config: BackoffConfig,
+        backoff_config: BackoffConfig
     ) -> Self {
         Self {
             brokers,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -3,11 +3,12 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use crate::{
+    backoff::BackoffConfig,
     build_info::DEFAULT_CLIENT_ID,
     client::partition::PartitionClient,
     connection::{BrokerConnector, MetadataLookupMode, TlsConfig},
     protocol::primitives::Boolean,
-    topic::Topic, backoff::BackoffConfig,
+    topic::Topic,
 };
 
 pub mod consumer;
@@ -55,7 +56,7 @@ impl ClientBuilder {
             max_message_size: 100 * 1024 * 1024, // 100MB
             socks5_proxy: None,
             tls_config: TlsConfig::default(),
-            backoff_config: None
+            backoff_config: None,
         }
     }
 
@@ -75,6 +76,7 @@ impl ClientBuilder {
         self
     }
 
+    /// Set up backoff configuration
     pub fn backoff_config(mut self, backoff_config: BackoffConfig) -> Self {
         self.backoff_config = Some(backoff_config);
         self
@@ -103,10 +105,14 @@ impl ClientBuilder {
             self.tls_config,
             self.socks5_proxy,
             self.max_message_size,
+            self.backoff_config,
         ));
         brokers.refresh_metadata().await?;
 
-        Ok(Client { brokers })
+        Ok(Client {
+            brokers,
+            backoff_config: self.backoff_config,
+        })
     }
 }
 
@@ -125,12 +131,16 @@ impl std::fmt::Debug for ClientBuilder {
 #[derive(Debug)]
 pub struct Client {
     brokers: Arc<BrokerConnector>,
+    backoff_config: Option<BackoffConfig>,
 }
 
 impl Client {
     /// Returns a client for performing certain cluster-wide operations.
     pub fn controller_client(&self) -> Result<ControllerClient> {
-        Ok(ControllerClient::new(Arc::clone(&self.brokers)))
+        Ok(ControllerClient::new(
+            Arc::clone(&self.brokers),
+            self.backoff_config,
+        ))
     }
 
     /// Returns a client for performing operations on a specific partition
@@ -145,6 +155,7 @@ impl Client {
             partition,
             Arc::clone(&self.brokers),
             unknown_topic_handling,
+            self.backoff_config,
         )
         .await
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -44,7 +44,7 @@ pub struct ClientBuilder {
     max_message_size: usize,
     socks5_proxy: Option<String>,
     tls_config: TlsConfig,
-    backoff_config: Option<BackoffConfig>,
+    backoff_config: BackoffConfig,
 }
 
 impl ClientBuilder {
@@ -56,7 +56,7 @@ impl ClientBuilder {
             max_message_size: 100 * 1024 * 1024, // 100MB
             socks5_proxy: None,
             tls_config: TlsConfig::default(),
-            backoff_config: None,
+            backoff_config: Default::default(),
         }
     }
 
@@ -78,7 +78,7 @@ impl ClientBuilder {
 
     /// Set up backoff configuration
     pub fn backoff_config(mut self, backoff_config: BackoffConfig) -> Self {
-        self.backoff_config = Some(backoff_config);
+        self.backoff_config = backoff_config;
         self
     }
 
@@ -131,7 +131,7 @@ impl std::fmt::Debug for ClientBuilder {
 #[derive(Debug)]
 pub struct Client {
     brokers: Arc<BrokerConnector>,
-    backoff_config: Option<BackoffConfig>,
+    backoff_config: BackoffConfig,
 }
 
 impl Client {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     client::partition::PartitionClient,
     connection::{BrokerConnector, MetadataLookupMode, TlsConfig},
     protocol::primitives::Boolean,
-    topic::Topic,
+    topic::Topic, backoff::BackoffConfig,
 };
 
 pub mod consumer;
@@ -43,6 +43,7 @@ pub struct ClientBuilder {
     max_message_size: usize,
     socks5_proxy: Option<String>,
     tls_config: TlsConfig,
+    backoff_config: Option<BackoffConfig>,
 }
 
 impl ClientBuilder {
@@ -54,6 +55,7 @@ impl ClientBuilder {
             max_message_size: 100 * 1024 * 1024, // 100MB
             socks5_proxy: None,
             tls_config: TlsConfig::default(),
+            backoff_config: None
         }
     }
 
@@ -70,6 +72,11 @@ impl ClientBuilder {
     /// failures all over the place since metadata requests cannot be handled any longer.
     pub fn max_message_size(mut self, max_message_size: usize) -> Self {
         self.max_message_size = max_message_size;
+        self
+    }
+
+    pub fn backoff_config(mut self, backoff_config: BackoffConfig) -> Self {
+        self.backoff_config = Some(backoff_config);
         self
     }
 

--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -123,7 +123,7 @@ pub struct PartitionClient {
     partition: i32,
     brokers: Arc<BrokerConnector>,
 
-    backoff_config: BackoffConfig,
+    backoff_config: Arc<BackoffConfig>,
 
     /// Current broker connection if any
     current_broker: Mutex<CurrentBroker>,
@@ -143,7 +143,7 @@ impl PartitionClient {
         partition: i32,
         brokers: Arc<BrokerConnector>,
         unknown_topic_handling: UnknownTopicHandling,
-        backoff_config: BackoffConfig,
+        backoff_config: Arc<BackoffConfig>,
     ) -> Result<Self> {
         let p = Self {
             topic,

--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -143,13 +143,13 @@ impl PartitionClient {
         partition: i32,
         brokers: Arc<BrokerConnector>,
         unknown_topic_handling: UnknownTopicHandling,
-        backoff_config: Option<BackoffConfig>,
+        backoff_config: BackoffConfig,
     ) -> Result<Self> {
         let p = Self {
             topic,
             partition,
             brokers: Arc::clone(&brokers),
-            backoff_config: backoff_config.unwrap_or_default(),
+            backoff_config,
             current_broker: Mutex::new(CurrentBroker {
                 broker: None,
                 gen_broker: BrokerCacheGeneration::START,

--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -143,12 +143,13 @@ impl PartitionClient {
         partition: i32,
         brokers: Arc<BrokerConnector>,
         unknown_topic_handling: UnknownTopicHandling,
+        backoff_config: Option<BackoffConfig>,
     ) -> Result<Self> {
         let p = Self {
             topic,
             partition,
             brokers: Arc::clone(&brokers),
-            backoff_config: Default::default(),
+            backoff_config: backoff_config.unwrap_or_default(),
             current_broker: Mutex::new(CurrentBroker {
                 broker: None,
                 gen_broker: BrokerCacheGeneration::START,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -187,6 +187,7 @@ impl BrokerConnector {
         tls_config: TlsConfig,
         socks5_proxy: Option<String>,
         max_message_size: usize,
+        backoff_config: Option<BackoffConfig>,
     ) -> Self {
         Self {
             bootstrap_brokers,
@@ -194,7 +195,7 @@ impl BrokerConnector {
             topology: Default::default(),
             cached_arbitrary_broker: Mutex::new((None, BrokerCacheGeneration::START)),
             cached_metadata: Default::default(),
-            backoff_config: Default::default(),
+            backoff_config: backoff_config.unwrap_or_default(),
             tls_config,
             socks5_proxy,
             max_message_size,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -187,7 +187,7 @@ impl BrokerConnector {
         tls_config: TlsConfig,
         socks5_proxy: Option<String>,
         max_message_size: usize,
-        backoff_config: Option<BackoffConfig>,
+        backoff_config: BackoffConfig,
     ) -> Self {
         Self {
             bootstrap_brokers,
@@ -195,7 +195,7 @@ impl BrokerConnector {
             topology: Default::default(),
             cached_arbitrary_broker: Mutex::new((None, BrokerCacheGeneration::START)),
             cached_metadata: Default::default(),
-            backoff_config: backoff_config.unwrap_or_default(),
+            backoff_config,
             tls_config,
             socks5_proxy,
             max_message_size,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -168,7 +168,7 @@ pub struct BrokerConnector {
     cached_metadata: MetadataCache,
 
     /// The backoff configuration on error
-    backoff_config: BackoffConfig,
+    backoff_config: Arc<BackoffConfig>,
 
     /// TLS configuration if any
     tls_config: TlsConfig,
@@ -187,7 +187,7 @@ impl BrokerConnector {
         tls_config: TlsConfig,
         socks5_proxy: Option<String>,
         max_message_size: usize,
-        backoff_config: BackoffConfig,
+        backoff_config: Arc<BackoffConfig>,
     ) -> Self {
         Self {
             bootstrap_brokers,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
     clippy::disallowed_methods
 )]
 
-mod backoff;
+pub mod backoff;
 
 pub mod build_info;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,9 @@
     clippy::disallowed_methods
 )]
 
-pub mod backoff;
+mod backoff;
+
+pub use backoff::BackoffConfig;
 
 pub mod build_info;
 


### PR DESCRIPTION
Describe your proposed changes here.

This changes will allow users to configure backoff/retry to their liking. This is also one of a 2 part changes (other still in progress) in an attempt to also allow a form of termination and not try forever especially without informing the user of the progress.

- [x] I've read the contributing section of the project [CONTRIBUTING.md](https://github.com/influxdata/rskafka/blob/main/CONTRIBUTING.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
