### PR TITLE
chore: upgrade to Rust 1.72

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rskafka"
 version = "0.5.0"
 edition = "2021"
+rust-version = "1.72"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.65"
+channel = "1.72"
 components = [ "rustfmt", "clippy" ]

--- a/src/client/consumer.rs
+++ b/src/client/consumer.rs
@@ -307,7 +307,7 @@ impl Stream for StreamConsumer {
                     *this.last_high_watermark = watermark;
                     if let Some(x) = records_and_offsets.last() {
                         *this.next_offset = Some(x.offset + 1);
-                        this.buffer.extend(records_and_offsets.into_iter())
+                        this.buffer.extend(records_and_offsets)
                     }
                     continue;
                 }
@@ -480,7 +480,7 @@ mod tests {
 
                                 buffer.push(RecordAndOffset {
                                     record,
-                                    offset: record_offset as i64,
+                                    offset: record_offset,
                                 });
                                 buffered += size
                             }

--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -665,7 +665,7 @@ fn build_produce_request(
             ProtocolRecord {
                 key: record.key,
                 value: record.value,
-                timestamp_delta: (record.timestamp - first_timestamp).num_milliseconds() as i64,
+                timestamp_delta: (record.timestamp - first_timestamp).num_milliseconds(),
                 offset_delta: offset_delta as i32,
                 headers: record
                     .headers

--- a/src/connection/transport.rs
+++ b/src/connection/transport.rs
@@ -17,7 +17,9 @@ pub use sasl::SaslConfig;
 pub type TlsConfig = Option<Arc<rustls::ClientConfig>>;
 
 #[cfg(not(feature = "transport-tls"))]
-pub type TlsConfig = ();
+#[allow(missing_copy_implementations)]
+#[derive(Debug, Clone, Default)]
+pub struct TlsConfig();
 
 #[derive(Debug, Error)]
 #[non_exhaustive]

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -19,6 +19,7 @@
 //!
 //! [KIP-32]: https://cwiki.apache.org/confluence/display/KAFKA/KIP-32+-+Add+timestamps+to+Kafka+message
 //! [KIP-98]: https://cwiki.apache.org/confluence/display/KAFKA/KIP-98+-+Exactly+Once+Delivery+and+Transactional+Messaging
+#![allow(clippy::arc_with_non_send_sync)] // workaround for https://github.com/proptest-rs/proptest/issues/364
 use std::io::{Cursor, Read, Write};
 
 #[cfg(test)]

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -511,7 +511,7 @@ async fn test_produce_consume_size_cutoff() {
 
         async move {
             let (records, _high_watermark) = partition_client
-                .fetch_records(0, 1..(limit as i32), 1_000)
+                .fetch_records(0, 1..limit, 1_000)
                 .await
                 .unwrap();
             if records.len() == 1 {


### PR DESCRIPTION
Requires for our CI because `cargo-fuzz` no longer builds with this old version.
