### PR TITLE
feat: Minor improvements to error visibility

### DIFF
--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -28,13 +28,10 @@ impl Default for BackoffConfig {
 
 type SourceError = Box<dyn std::error::Error + Send + Sync>;
 
-// TODO: Currently, retrying can't fail, but there should be a global maximum timeout that
-// causes an error if the total time retrying exceeds that amount.
-// See https://github.com/influxdata/rskafka/issues/65
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_copy_implementations)]
 pub enum BackoffError {
-    #[error("Retry exceeded deadline")]
+    #[error("Retry exceeded deadline. Source: {source}")]
     DeadlineExceded {
         deadline: Duration,
         source: SourceError,
@@ -103,9 +100,6 @@ impl Backoff {
     }
 
     /// Perform an async operation that retries with a backoff
-    // TODO: Currently, this can't fail, but there should be a global maximum timeout that
-    // causes an error if the total time retrying exceeds that amount.
-    // See https://github.com/influxdata/rskafka/issues/65
     pub async fn retry_with_backoff<F, F1, B, E>(
         &mut self,
         request_name: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ pub mod client;
 
 mod connection;
 
+pub use connection::Error as ConnectionError;
+
 #[cfg(feature = "unstable-fuzzing")]
 pub mod messenger;
 #[cfg(not(feature = "unstable-fuzzing"))]

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -721,7 +721,15 @@ async fn test_client_backoff_terminates() {
 
     match client_builder.build().await {
         Err(rskafka::client::error::Error::Connection(e)) => {
-            assert_eq!(e.to_string(), "all retries failed: Retry exceeded deadline");
+            // Error can be slightly different depending on the exact underlying error.
+            assert!(
+                e.to_string().starts_with(concat!(
+                    "all retries failed: Retry exceeded deadline. ",
+                    "Source: error connecting to broker \"localhost:9000\""
+                )),
+                "expected error to start with \"all retries failed...\", actual: {}",
+                e
+            );
         }
         _ => {
             unreachable!();


### PR DESCRIPTION
This PR makes a few small changes:

 - Changes the derived display impl of `BackoffError` to also include the `source` error.
 - Removes a few unhelpful TODO's, which are no longer correct.
 - Exposes `connection::Error` as `ConnectionError`. Currently it is not visible at all, since `connection` is a private module.
 - Captures errors from broker connection and passes that along too.

Nothing should be breaking or particularly intrusive.

- [x] I've read the contributing section of the project [CONTRIBUTING.md](https://github.com/influxdata/rskafka/blob/main/CONTRIBUTING.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
