### PR TITLE
build(deps): Update crc32c version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ async-socks5 = { version = "0.6", optional = true }
 async-trait = "0.1"
 bytes = "1.1"
 chrono = { version = "0.4", default-features = false }
-crc32c = "0.6.5"
+crc32c = "0.6.8"
 flate2 = { version = "1", optional = true }
 futures = "0.3"
 integer-encoding = "4"


### PR DESCRIPTION
Fix this compilation issue:

```
error[E0658]: use of unstable library feature 'stdarch_arm_crc32'
  --> /Users/tison/.cargo/registry/src/index.crates.io-6f17d22bba15001f/crc32c-0.6.8/src/hw_aarch64.rs:50:33
   |
50 |         .fold(crc, |crc, &next| simd::__crc32cb(crc, next))
   |                                 ^^^^^^^^^^^^^^^
   |
   = note: see issue #117215 <https://github.com/rust-lang/rust/issues/117215> for more information
   = help: add `#![feature(stdarch_arm_crc32)]` to the crate attributes to enable
   = note: this compiler was built on 2024-05-11; consider upgrading it if it is out of date

error[E0658]: use of unstable library feature 'stdarch_arm_crc32'
  --> /Users/tison/.cargo/registry/src/index.crates.io-6f17d22bba15001f/crc32c-0.6.8/src/hw_aarch64.rs:62:5
   |
62 |     simd::__crc32cd(crc, next)
   |     ^^^^^^^^^^^^^^^
   |
   = note: see issue #117215 <https://github.com/rust-lang/rust/issues/117215> for more information
   = help: add `#![feature(stdarch_arm_crc32)]` to the crate attributes to enable
   = note: this compiler was built on 2024-05-11; consider upgrading it if it is out of date
```