### PR TITLE
chore: drop `pin-project-lite`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ futures = "0.3"
 integer-encoding = "4"
 lz4 = { version = "1.23", optional = true }
 parking_lot = "0.12"
-pin-project-lite = "0.2"
 rand = "0.8"
 rustls = { version = "0.23", optional = true, default-features = false, features = ["logging", "ring", "std", "tls12"] }
 snap = { version = "1", optional = true }

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -11,9 +11,8 @@ use chrono::{TimeZone, Utc};
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion, SamplingMode,
 };
-use futures::{stream::FuturesUnordered, StreamExt, TryStreamExt};
+use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryStreamExt};
 use parking_lot::Once;
-use pin_project_lite::pin_project;
 use rdkafka::{
     consumer::{Consumer, StreamConsumer as RdStreamConsumer},
     producer::{FutureProducer, FutureRecord},
@@ -256,17 +255,14 @@ where
     fn time_it(self) -> Self::TimeItFut {
         TimeIt {
             t_start: Instant::now(),
-            inner: self,
+            inner: Box::pin(self),
         }
     }
 }
 
-pin_project! {
-    struct TimeIt<F> {
-        t_start: Instant,
-        #[pin]
-        inner: F,
-    }
+struct TimeIt<F> {
+    t_start: Instant,
+    inner: Pin<Box<F>>,
 }
 
 impl<F> Future for TimeIt<F>
@@ -275,10 +271,9 @@ where
 {
     type Output = Duration;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        match this.inner.poll(cx) {
-            Poll::Ready(_) => Poll::Ready(this.t_start.elapsed()),
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        match self.inner.poll_unpin(cx) {
+            Poll::Ready(_) => Poll::Ready(self.t_start.elapsed()),
             Poll::Pending => Poll::Pending,
         }
     }


### PR DESCRIPTION
Actually we don't need this, all our nested types fall roughly into three categories:

- **no perf critical:** Use `Box::pin` to create a new allocation `Pin<Box<T>>`
- **already alloated:** They where already wrapped in a `Box<T>` (e.g. for enums with vastly different variants), so `Pin<Box<T>>` is the same overhead.
- **`Unpin`:** Some upstream types implement `Unpin`, so you can just use `Pin::new(&mut x)`.
