### PR TITLE
feat: add `timestamp-query` feature to allow timestamp offset query

### DIFF
--- a/src/client/consumer.rs
+++ b/src/client/consumer.rs
@@ -502,6 +502,9 @@ mod tests {
                 match at {
                     OffsetAt::Earliest => Ok(inner.lock().await.range.0),
                     OffsetAt::Latest => Ok(inner.lock().await.range.1),
+                    OffsetAt::Timestamp(_) => {
+                        unreachable!("timestamp based offset is tested in e2e test")
+                    }
                 }
             })
         }


### PR DESCRIPTION
This commit allow timestamp query for partition offset. As stated in the doc comment of `OffsetAt`, timestamp-based query is inconsistent, but I think it better to let the users make their own choice instead of total removal of this sometimes useful feature. I add a feature gate to  disable timestamp-based query for offset by default, only those actively looking for timestamp-based query would enable this feature.

- [X] I've read the contributing section of the project [CONTRIBUTING.md](https://github.com/influxdata/rskafka/blob/main/CONTRIBUTING.md).
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
