### PR TITLE
chore: do not reinstall cargo deny in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,14 +105,9 @@ jobs:
     steps:
       - checkout
       - rust_components
-      - cache_restore
-      - run:
-          name: Install cargo-deny
-          command: cargo install cargo-deny
       - run:
           name: cargo-deny Checks
           command: cargo deny check -s
-      - cache_save
   doc:
     docker:
       - image: quay.io/influxdb/rust:ci


### PR DESCRIPTION
This is already part of the CI image.