### PR TITLE
revert: chore(deps): update rdkafka requirement from 0.35 to 0.37

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ j4rs = "0.20.0"
 proptest = "1"
 proptest-derive = "0.5"
 rustls-pemfile = "2.0"
-rdkafka = { version = "0.37", default-features = false, features = ["libz", "tokio", "zstd"] }
+rdkafka = { version = "0.35", default-features = false, features = ["libz", "tokio", "zstd"] }
 tokio = { version = "1.14", features = ["macros", "rt-multi-thread"] }
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
Reverts #242.

It seems that newer rdkafka versions fail sometimes when they encounter host resolution errors. However if you have multiple bootstrap brokers, failing to resolve one of them should be totally valid and can happen in production environments. We test this behavior in our CI pipeline and rskafka is totally fine with it.