### PR TITLE
feat: connection timeout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod client;
 mod connection;
 
 pub use connection::Error as ConnectionError;
+pub use connection::TransportError;
 pub use messenger::SaslError;
 
 #[cfg(feature = "unstable-fuzzing")]


### PR DESCRIPTION
Closes #268

Add support for setting a connection timeout for establishing TCP connections. Having the option for a timeout here is good to prevent the client from getting stuck if some weird network errors happen while connecting, which we've seen a few times.

I had to allow the clippy too-many-arguments lint on two internal methods since we need to pass the timeout parameter down the stack. Fixing this would take a larger refactor than I think is appropriate for this change.

The default value is set to 30 seconds as suggested.

I tried to write a more meaningful test, but ended up with one that just times out instantly. It's hard to create a test for this since connecting to an actually closed port will just produce "Connection refused", and relying on a connection being "slow" is almost guaranteed to produce a flaky test. This does verify that a timeout parameter is passed all the way down, so it's better than nothing.

- [x] I've read the contributing section of the project [CONTRIBUTING.md](https://github.com/influxdata/rskafka/blob/main/CONTRIBUTING.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
