### PR TITLE
chore: update rust, fix deprecations & lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rskafka"
 version = "0.6.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = [

--- a/fuzz/fuzz_targets/protocol_reader.rs
+++ b/fuzz/fuzz_targets/protocol_reader.rs
@@ -104,7 +104,7 @@ fn driver(data: &[u8]) -> Result<(), Error> {
             api_key,
             api_version,
         ),
-        _ => Err(format!("Fuzzing not implemented for: {:?}", api_key).into()),
+        _ => Err(format!("Fuzzing not implemented for: {api_key:?}").into()),
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85"
+channel = "1.88"
 components = [ "rustfmt", "clippy" ]

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -175,7 +175,6 @@ impl Iterator for Backoff {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::rngs::mock::StepRng;
 
     #[test]
     fn test_backoff() {
@@ -193,7 +192,7 @@ mod tests {
         let assert_fuzzy_eq = |a: f64, b: f64| assert!((b - a).abs() < 0.0001, "{a} != {b}");
 
         // Create a static rng that takes the minimum of the range
-        let rng = Box::new(StepRng::new(0, 0));
+        let rng = Box::new(ConstantRng::new(0));
         let mut backoff = Backoff::new_with_rng(&config, Some(rng));
 
         for _ in 0..20 {
@@ -201,7 +200,7 @@ mod tests {
         }
 
         // Create a static rng that takes the maximum of the range
-        let rng = Box::new(StepRng::new(u64::MAX, 0));
+        let rng = Box::new(ConstantRng::new(u64::MAX));
         let mut backoff = Backoff::new_with_rng(&config, Some(rng));
 
         for i in 0..20 {
@@ -210,7 +209,7 @@ mod tests {
         }
 
         // Create a static rng that takes the mid point of the range
-        let rng = Box::new(StepRng::new(u64::MAX / 2, 0));
+        let rng = Box::new(ConstantRng::new(u64::MAX / 2));
         let mut backoff = Backoff::new_with_rng(&config, Some(rng));
 
         let mut value = init_backoff_secs;
@@ -221,7 +220,7 @@ mod tests {
         }
 
         // deadline
-        let rng = Box::new(StepRng::new(u64::MAX, 0));
+        let rng = Box::new(ConstantRng::new(u64::MAX));
         let deadline = Duration::from_secs_f64(init_backoff_secs);
         let mut backoff = Backoff::new_with_rng(
             &BackoffConfig {
@@ -231,5 +230,30 @@ mod tests {
             Some(rng),
         );
         assert_eq!(backoff.next(), None);
+    }
+
+    /// A simple RNG that always returns the same value
+    struct ConstantRng {
+        value: u64,
+    }
+
+    impl ConstantRng {
+        fn new(value: u64) -> Self {
+            Self { value }
+        }
+    }
+
+    impl RngCore for ConstantRng {
+        fn next_u32(&mut self) -> u32 {
+            (self.value >> 32) as u32
+        }
+
+        fn next_u64(&mut self) -> u64 {
+            self.value
+        }
+
+        fn fill_bytes(&mut self, _dest: &mut [u8]) {
+            unimplemented!()
+        }
     }
 }

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -190,7 +190,7 @@ mod tests {
             deadline: None,
         };
 
-        let assert_fuzzy_eq = |a: f64, b: f64| assert!((b - a).abs() < 0.0001, "{} != {}", a, b);
+        let assert_fuzzy_eq = |a: f64, b: f64| assert!((b - a).abs() < 0.0001, "{a} != {b}");
 
         // Create a static rng that takes the minimum of the range
         let rng = Box::new(StepRng::new(0, 0));

--- a/src/client/consumer.rs
+++ b/src/client/consumer.rs
@@ -448,7 +448,7 @@ mod tests {
                     buffered += size;
                 }
 
-                println!("Waiting up to {} ms for more data", max_wait_ms);
+                println!("Waiting up to {max_wait_ms} ms for more data");
 
                 // Need to wait for more data
                 let timeout = tokio::time::sleep(Duration::from_millis(max_wait_ms as u64)).fuse();

--- a/src/client/controller.rs
+++ b/src/client/controller.rs
@@ -186,8 +186,7 @@ impl BrokerCache for &ControllerClient {
         let controller_id = self.get_controller_id().await?;
         let broker = self.brokers.connect(controller_id).await?.ok_or_else(|| {
             Error::InvalidResponse(format!(
-                "Controller {} not found in metadata response",
-                controller_id
+                "Controller {controller_id} not found in metadata response"
             ))
         })?;
 

--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -450,8 +450,7 @@ impl BrokerCache for &PartitionClient {
                     );
                 }
                 Err(Error::InvalidResponse(format!(
-                    "Partition leader {} not found in metadata response",
-                    leader
+                    "Partition leader {leader} not found in metadata response"
                 )))
             }
             Err(e) => {
@@ -972,8 +971,7 @@ fn extract_offset(partition: ListOffsetsResponsePartition) -> Result<i64> {
             Some(offsets) => match offsets.len() {
                 1 => Ok(offsets[0].0),
                 n => Err(Error::InvalidResponse(format!(
-                    "Expected 1 offset to be returned but got {}",
-                    n
+                    "Expected 1 offset to be returned but got {n}"
                 ))),
             },
             None => Err(Error::InvalidResponse(

--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -633,7 +633,7 @@ fn sorted_ranges_repr(ranges: &HashMap<ApiKey, ApiVersionRange>) -> String {
     ranges.sort_by_key(|(key, _range)| *key);
     let ranges: Vec<_> = ranges
         .into_iter()
-        .map(|(key, range)| format!("{:?}: {}", key, range))
+        .map(|(key, range)| format!("{key:?}: {range}"))
         .collect();
     ranges.join(", ")
 }

--- a/src/protocol/error.rs
+++ b/src/protocol/error.rs
@@ -357,7 +357,7 @@ impl From<Option<Error>> for Int16 {
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/src/protocol/messages/mod.rs
+++ b/src/protocol/messages/mod.rs
@@ -140,7 +140,7 @@ fn read_versioned_array<R: Read, T: ReadVersionedType<R>>(
     match len {
         -1 => Ok(None),
         l if l < -1 => Err(ReadVersionedError::ReadError(ReadError::Malformed(
-            format!("Invalid negative length for array: {}", l).into(),
+            format!("Invalid negative length for array: {l}").into(),
         ))),
         _ => {
             let len = usize::try_from(len).map_err(ReadError::Overflow)?;

--- a/src/protocol/primitives.rs
+++ b/src/protocol/primitives.rs
@@ -293,7 +293,7 @@ where
         let len = Int16::read(reader)?;
         match len.0 {
             l if l < -1 => Err(ReadError::Malformed(
-                format!("Invalid negative length for nullable string: {}", l).into(),
+                format!("Invalid negative length for nullable string: {l}").into(),
             )),
             -1 => Ok(Self(None)),
             l => {
@@ -572,7 +572,7 @@ where
         let len = Int32::read(reader)?;
         match len.0 {
             l if l < -1 => Err(ReadError::Malformed(
-                format!("Invalid negative length for nullable bytes: {}", l).into(),
+                format!("Invalid negative length for nullable bytes: {l}").into(),
             )),
             -1 => Ok(Self(None)),
             l => {

--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -250,7 +250,7 @@ where
         let version = Int16::read(reader)?.0;
         if version != 0 {
             return Err(ReadError::Malformed(
-                format!("Unknown control batch record version: {}", version).into(),
+                format!("Unknown control batch record version: {version}").into(),
             ));
         }
 
@@ -260,7 +260,7 @@ where
             0 => Ok(Self::Abort),
             1 => Ok(Self::Commit),
             _ => Err(ReadError::Malformed(
-                format!("Unknown control batch record type: {}", t).into(),
+                format!("Unknown control batch record type: {t}").into(),
             )),
         }
     }
@@ -363,7 +363,7 @@ where
             + 4, // crc
             )
             .ok_or_else(|| {
-                ReadError::Malformed(format!("Record batch len too small: {}", len).into())
+                ReadError::Malformed(format!("Record batch len too small: {len}").into())
             })?;
 
         // partitionLeaderEpoch
@@ -373,7 +373,7 @@ where
         let magic = Int8::read(reader)?.0;
         if magic != 2 {
             return Err(ReadError::Malformed(
-                format!("Invalid magic number in record batch: {}", magic).into(),
+                format!("Invalid magic number in record batch: {magic}").into(),
             ));
         }
 
@@ -388,7 +388,7 @@ where
         let actual_crc = crc32c::crc32c(&data);
         if crc != actual_crc {
             return Err(ReadError::Malformed(
-                format!("CRC error, got 0x{:x}, expected 0x{:x}", actual_crc, crc).into(),
+                format!("CRC error, got 0x{actual_crc:x}, expected 0x{crc:x}").into(),
             ));
         }
 
@@ -403,7 +403,7 @@ where
         let bytes_left = bytes_total - bytes_read;
         if bytes_left != 0 {
             return Err(ReadError::Malformed(
-                format!("Found {} trailing bytes after RecordBatch", bytes_left).into(),
+                format!("Found {bytes_left} trailing bytes after RecordBatch").into(),
             ));
         }
 
@@ -521,7 +521,7 @@ impl RecordBatchBody {
         if is_control {
             if n_records != 1 {
                 return Err(ReadError::Malformed(
-                    format!("Expected 1 control record but got {}", n_records).into(),
+                    format!("Expected 1 control record but got {n_records}").into(),
                 ));
             }
 
@@ -552,7 +552,7 @@ where
             4 => RecordBatchCompression::Zstd,
             other => {
                 return Err(ReadError::Malformed(
-                    format!("Invalid compression type: {}", other).into(),
+                    format!("Invalid compression type: {other}").into(),
                 ));
             }
         };
@@ -695,7 +695,7 @@ where
             #[allow(unreachable_patterns)]
             _ => {
                 return Err(ReadError::Malformed(
-                    format!("Unimplemented compression: {:?}", compression).into(),
+                    format!("Unimplemented compression: {compression:?}").into(),
                 ));
             }
         };

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -114,7 +114,7 @@ async fn test_topic_crud() {
             protocol_error: ProtocolError::TopicAlreadyExists,
             ..
         } => {}
-        _ => panic!("Unexpected error: {}", err),
+        _ => panic!("Unexpected error: {err}"),
     }
 
     // delete one topic
@@ -730,8 +730,7 @@ async fn test_client_backoff_terminates() {
                     "all retries failed: Retry exceeded deadline. ",
                     "Source: error connecting to broker \"localhost:9000\""
                 )),
-                "expected error to start with \"all retries failed...\", actual: {}",
-                e
+                "expected error to start with \"all retries failed...\", actual: {e}"
             );
         }
         _ => {

--- a/tests/produce_consume.rs
+++ b/tests/produce_consume.rs
@@ -347,8 +347,7 @@ async fn assert_produce_consume<F1, G1, F2, G2>(
         .collect();
     assert_eq!(
         actual, expected,
-        "Records are different.\n\nActual:\n{:#?}\n\nExpected:\n{:#?}",
-        actual, expected,
+        "Records are different.\n\nActual:\n{actual:#?}\n\nExpected:\n{expected:#?}",
     );
 }
 

--- a/tests/rdkafka_helper.rs
+++ b/tests/rdkafka_helper.rs
@@ -129,10 +129,7 @@ pub async fn consume(
                 Err(e) => {
                     // this might happen on a fresh rdkafka node
                     // (e.g. "KafkaError (Message consumption error: NotCoordinator (Broker: Not coordinator))")
-                    println!(
-                        "Encountered rdkafka error while consuming, try again: {:?}",
-                        e
-                    );
+                    println!("Encountered rdkafka error while consuming, try again: {e:?}");
                     tokio::time::sleep(Duration::from_millis(100)).await;
                     continue;
                 }


### PR DESCRIPTION
The `StepRng` deprecation is blocking other PRs.