### PR TITLE
fix: parse control batch records from Record envelope key

### DIFF
--- a/src/protocol/record.rs
+++ b/src/protocol/record.rs
@@ -241,21 +241,22 @@ pub enum ControlBatchRecord {
     Commit,
 }
 
-impl<R> ReadType<R> for ControlBatchRecord
-where
-    R: Read,
-{
-    fn read(reader: &mut R) -> Result<Self, ReadError> {
-        // version
-        let version = Int16::read(reader)?.0;
+impl ControlBatchRecord {
+    /// Parse a `ControlBatchRecord` from a key byte slice.
+    ///
+    /// Per the Kafka spec, the control record's key contains:
+    ///   version: int16 (must be 0)
+    ///   type:    int16 (0 = ABORT, 1 = COMMIT)
+    fn from_key(key: &[u8]) -> Result<Self, ReadError> {
+        let mut cursor = Cursor::new(key);
+        let version = Int16::read(&mut cursor)?.0;
         if version != 0 {
             return Err(ReadError::Malformed(
                 format!("Unknown control batch record version: {version}").into(),
             ));
         }
 
-        // type
-        let t = Int16::read(reader)?.0;
+        let t = Int16::read(&mut cursor)?.0;
         match t {
             0 => Ok(Self::Abort),
             1 => Ok(Self::Commit),
@@ -266,22 +267,44 @@ where
     }
 }
 
+impl<R> ReadType<R> for ControlBatchRecord
+where
+    R: Read,
+{
+    fn read(reader: &mut R) -> Result<Self, ReadError> {
+        // A control batch record is wrapped in a standard Record envelope.
+        // Parse the Record first, then extract version/type from its key.
+        let record = Record::read(reader)?;
+        let key = record.key.ok_or_else(|| {
+            ReadError::Malformed("Control batch record has no key".into())
+        })?;
+        Self::from_key(&key)
+    }
+}
+
 impl<W> WriteType<W> for ControlBatchRecord
 where
     W: Write,
 {
     fn write(&self, writer: &mut W) -> Result<(), WriteError> {
-        // version
-        Int16(0).write(writer)?;
-
-        // type
-        let t = match self {
+        // Build the key: version (int16) + type (int16)
+        let mut key = Vec::with_capacity(4);
+        Int16(0).write(&mut key)?;
+        let t: i16 = match self {
             Self::Abort => 0,
             Self::Commit => 1,
         };
-        Int16(t).write(writer)?;
+        Int16(t).write(&mut key)?;
 
-        Ok(())
+        // Wrap in a standard Record envelope
+        let record = Record {
+            timestamp_delta: 0,
+            offset_delta: 0,
+            key: Some(key),
+            value: None,
+            headers: vec![],
+        };
+        record.write(writer)
     }
 }
 
@@ -1022,12 +1045,28 @@ mod tests {
 
     test_roundtrip!(ControlBatchRecord, test_control_batch_record_roundtrip);
 
+    /// Helper: wrap a control-batch key (version + type as raw bytes) inside
+    /// a Record envelope so that `ControlBatchRecord::read` can parse it.
+    fn wrap_control_key_in_record(key_bytes: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let record = Record {
+            timestamp_delta: 0,
+            offset_delta: 0,
+            key: Some(key_bytes.to_vec()),
+            value: None,
+            headers: vec![],
+        };
+        record.write(&mut buf).unwrap();
+        buf
+    }
+
     #[test]
     fn test_control_batch_record_unknown_version() {
-        let mut buf = Cursor::new(Vec::<u8>::new());
-        Int16(1).write(&mut buf).unwrap();
-        Int16(0).write(&mut buf).unwrap();
-        buf.set_position(0);
+        let mut key = Vec::new();
+        Int16(1).write(&mut key).unwrap();
+        Int16(0).write(&mut key).unwrap();
+        let data = wrap_control_key_in_record(&key);
+        let mut buf = Cursor::new(data);
 
         let err = ControlBatchRecord::read(&mut buf).unwrap_err();
         assert_matches!(err, ReadError::Malformed(_));
@@ -1039,10 +1078,11 @@ mod tests {
 
     #[test]
     fn test_control_batch_record_unknown_type() {
-        let mut buf = Cursor::new(Vec::<u8>::new());
-        Int16(0).write(&mut buf).unwrap();
-        Int16(2).write(&mut buf).unwrap();
-        buf.set_position(0);
+        let mut key = Vec::new();
+        Int16(0).write(&mut key).unwrap();
+        Int16(2).write(&mut key).unwrap();
+        let data = wrap_control_key_in_record(&key);
+        let mut buf = Cursor::new(data);
 
         let err = ControlBatchRecord::read(&mut buf).unwrap_err();
         assert_matches!(err, ReadError::Malformed(_));


### PR DESCRIPTION
## Summary

Fixes parsing of Kafka transactional control batch records. Per the [Kafka protocol spec](https://kafka.apache.org/documentation/#controlbatch), control batch records are wrapped in a standard `Record` envelope — the version and type `Int16` fields are encoded in the Record's **key** field, not directly in the raw byte stream.

The current implementation reads version/type directly from the stream, which causes the `Record` length varint to be misinterpreted as the version field, producing:

```
Unknown control batch record version: 8192
```

This breaks consumption of any topic written by Flink SQL, ksqlDB, or Kafka Streams with `processing.guarantee=exactly_once`, since those frameworks use transactional producers that write commit/abort control batches.

## Changes

- **`ControlBatchRecord::read`**: Now reads a `Record` envelope first, then parses version/type from the Record's key field via a new `from_key()` helper.
- **`ControlBatchRecord::write`**: Now wraps the 4-byte key (version + type) inside a `Record` envelope for correct round-trip serialization.
- **Tests**: Updated to construct control batch records inside Record envelopes using a `wrap_control_key_in_record` helper. Roundtrip test continues to pass.

## Test plan

- [x] `cargo check --lib` passes
- [x] Roundtrip proptest (`test_control_batch_record_roundtrip`) passes
- [x] `test_control_batch_record_unknown_version` passes with envelope-wrapped input
- [x] `test_control_batch_record_unknown_type` passes with envelope-wrapped input
- [x] Verified against Confluent Cloud: successfully consumed messages from Flink SQL transactional output topics (`good-jokes-*`) that previously failed with "Unknown control batch record version: 8192"

## Reproduction

1. Create a Flink SQL job that writes to a Kafka topic (uses transactional producer internally)
2. Attempt to consume from the output topic using rskafka
3. Observe `ReadError::Malformed("Unknown control batch record version: 8192")`
4. With this fix, control batches are correctly parsed and consumption succeeds