### PR TITLE
feat: return response size

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It will be a good fit for workloads that:
 use rskafka::{
     client::{
         ClientBuilder,
-        partition::{Compression, UnknownTopicHandling},
+        partition::{Compression, FetchResult, UnknownTopicHandling},
     },
     record::Record,
 };
@@ -74,14 +74,18 @@ let record = Record {
 partition_client.produce(vec![record], Compression::default()).await.unwrap();
 
 // consume data
-let (records, high_watermark) = partition_client
+let FetchResult {
+    records,
+    high_watermark,
+    ..
+} = partition_client
     .fetch_records(
         0,  // offset
         1..1_000_000,  // min..max bytes
         1_000,  // max wait time
     )
-   .await
-   .unwrap();
+    .await
+    .unwrap();
 # }
 ```
 

--- a/src/client/consumer.rs
+++ b/src/client/consumer.rs
@@ -172,7 +172,7 @@ trait FetchClient: std::fmt::Debug + Send + Sync {
         offset: i64,
         bytes: Range<i32>,
         max_wait_ms: i32,
-    ) -> BoxFuture<'_, Result<(Vec<RecordAndOffset>, i64)>>;
+    ) -> BoxFuture<'_, Result<crate::client::partition::FetchResult>>;
 
     /// Get offset.
     ///
@@ -186,7 +186,7 @@ impl FetchClient for PartitionClient {
         offset: i64,
         bytes: Range<i32>,
         max_wait_ms: i32,
-    ) -> BoxFuture<'_, Result<(Vec<RecordAndOffset>, i64)>> {
+    ) -> BoxFuture<'_, Result<crate::client::partition::FetchResult>> {
         Box::pin(self.fetch_records(offset, bytes, max_wait_ms))
     }
 
@@ -268,8 +268,11 @@ impl Stream for StreamConsumer {
                         },
                     };
 
-                    let (records_and_offsets, watermark) =
-                        client.fetch_records(offset, bytes, max_wait_ms).await?;
+                    let crate::client::partition::FetchResult {
+                        records: records_and_offsets,
+                        high_watermark: watermark,
+                        ..
+                    } = client.fetch_records(offset, bytes, max_wait_ms).await?;
                     Ok(FetchResultOk {
                         records_and_offsets,
                         watermark,
@@ -368,6 +371,7 @@ mod tests {
     use futures::{StreamExt, pin_mut};
     use tokio::sync::{Mutex, mpsc};
 
+    use crate::client::partition::FetchResult;
     use crate::{
         client::error::{Error, ProtocolError, RequestContext},
         record::Record,
@@ -413,7 +417,7 @@ mod tests {
             start_offset: i64,
             bytes: Range<i32>,
             max_wait_ms: i32,
-        ) -> BoxFuture<'_, Result<(Vec<RecordAndOffset>, i64)>> {
+        ) -> BoxFuture<'_, Result<FetchResult>> {
             let inner = Arc::clone(&self.inner);
             Box::pin(async move {
                 if let Some(err) = inner.lock().await.next_err.take() {
@@ -491,7 +495,11 @@ mod tests {
 
                 inner.batch_sizes.push(buffer.len());
 
-                Ok((buffer, inner.buffer.len() as i64 - 1))
+                Ok(FetchResult {
+                    records: buffer,
+                    high_watermark: inner.buffer.len() as i64 - 1,
+                    encoded_response_size: 0,
+                })
             })
         }
 

--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -113,6 +113,20 @@ struct CurrentBroker {
     gen_leader_from_self: Option<MetadataCacheGeneration>,
 }
 
+/// The result of the [fetch_records](PartitionClient::fetch_records) call.
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct FetchResult {
+    /// The offsets of the fetched records.
+    pub records: Vec<RecordAndOffset>,
+
+    /// The high watermark of the partition.
+    pub high_watermark: i64,
+
+    /// The size of the response encoded in bytes.
+    pub encoded_response_size: usize,
+}
+
 /// Many operations must be performed on the leader for a partition
 ///
 /// Additionally a partition is the unit of concurrency within Kafka
@@ -221,6 +235,7 @@ impl PartitionClient {
                 let ResponseBodyWithMetadata {
                     response,
                     encoded_request_size,
+                    ..
                 } = broker
                     .request(&request)
                     .await
@@ -251,10 +266,10 @@ impl PartitionClient {
         offset: i64,
         bytes: Range<i32>,
         max_wait_ms: i32,
-    ) -> Result<(Vec<RecordAndOffset>, i64)> {
+    ) -> Result<FetchResult> {
         let request = &build_fetch_request(offset, bytes, max_wait_ms, self.partition, &self.topic);
 
-        let partition = maybe_retry(
+        let (partition, response_size) = maybe_retry(
             &self.backoff_config,
             self.unknown_topic_handling,
             self,
@@ -264,13 +279,17 @@ impl PartitionClient {
                     .get()
                     .await
                     .map_err(|e| ErrorOrThrottle::Error((e, None)))?;
-                let response = broker
+                let ResponseBodyWithMetadata {
+                    response,
+                    encoded_response_size,
+                    ..
+                } = broker
                     .request(&request)
                     .await
-                    .map_err(|e| ErrorOrThrottle::Error((e.into(), Some(r#gen))))?
-                    .response;
+                    .map_err(|e| ErrorOrThrottle::Error((e.into(), Some(r#gen))))?;
                 maybe_throttle(response.throttle_time_ms)?;
                 process_fetch_response(self.partition, &self.topic, response, offset)
+                    .map(|r| (r, encoded_response_size))
                     .map_err(|e| ErrorOrThrottle::Error((e, Some(r#gen))))
             },
         )
@@ -278,7 +297,11 @@ impl PartitionClient {
 
         let records = extract_records(partition.records.0, offset)?;
 
-        Ok((records, partition.high_watermark.0))
+        Ok(FetchResult {
+            records,
+            high_watermark: partition.high_watermark.0,
+            encoded_response_size: response_size,
+        })
     }
 
     /// Get offset for this partition.

--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -113,7 +113,7 @@ struct CurrentBroker {
     gen_leader_from_self: Option<MetadataCacheGeneration>,
 }
 
-/// The result of the [fetch_records](PartitionClient::fetch_records) call.
+/// The result of [`PartitionClient::fetch_records`].
 #[derive(Debug, Default)]
 #[non_exhaustive]
 pub struct FetchResult {

--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -432,6 +432,7 @@ where
             rx.await
         }
         .expect("Who closed this channel?!")?;
+        let response_size = response.data.get_ref().len();
         let body = R::ResponseBody::read_versioned(&mut response.data, body_api_version)?;
 
         // check if we fully consumed the message, otherwise there might be a bug in our protocol code
@@ -449,6 +450,7 @@ where
         Ok(ResponseBodyWithMetadata {
             response: body,
             encoded_request_size: encoded_size,
+            encoded_response_size: response_size,
         })
     }
 

--- a/src/protocol/messages/mod.rs
+++ b/src/protocol/messages/mod.rs
@@ -94,6 +94,9 @@ pub struct ResponseBodyWithMetadata<R> {
 
     /// The size of the request encoded in bytes.
     pub encoded_request_size: usize,
+
+    /// The size of the response encoded in bytes.
+    pub encoded_response_size: usize,
 }
 
 /// Specifies a request body.

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -5,7 +5,7 @@ use rskafka::{
     client::{
         ClientBuilder,
         error::{Error as ClientError, ProtocolError, ServerErrorResponse},
-        partition::{Compression, OffsetAt, UnknownTopicHandling},
+        partition::{Compression, FetchResult, OffsetAt, UnknownTopicHandling},
         producer::ProduceResult,
     },
     record::{Record, RecordAndOffset},
@@ -299,7 +299,11 @@ async fn test_socks5() {
         .await
         .unwrap();
 
-    let (mut records, _watermark) = partition_client
+    let FetchResult {
+        mut records,
+        high_watermark: _,
+        ..
+    } = partition_client
         .fetch_records(0, 1..10_000_001, 1_000)
         .await
         .unwrap();
@@ -358,7 +362,11 @@ async fn test_consume_empty() {
         .partition_client(&topic_name, 1, UnknownTopicHandling::Retry)
         .await
         .unwrap();
-    let (records, watermark) = partition_client
+    let FetchResult {
+        records,
+        high_watermark: watermark,
+        ..
+    } = partition_client
         .fetch_records(0, 1..10_000, 1_000)
         .await
         .unwrap();
@@ -584,7 +592,11 @@ async fn test_produce_consume_size_cutoff() {
         let record_2 = record_2.clone();
 
         async move {
-            let (records, _high_watermark) = partition_client
+            let FetchResult {
+                records,
+                high_watermark: _,
+                ..
+            } = partition_client
                 .fetch_records(0, 1..limit, 1_000)
                 .await
                 .unwrap();
@@ -649,7 +661,11 @@ async fn test_consume_midbatch() {
 
     // when fetching from the middle of the record batch, the server will return both records but we should filter out
     // the first one on the client side
-    let (records, _watermark) = partition_client
+    let FetchResult {
+        records,
+        high_watermark: _,
+        ..
+    } = partition_client
         .fetch_records(offset_2, 1..10_000, 1_000)
         .await
         .unwrap();
@@ -752,7 +768,11 @@ async fn test_delete_records() {
 
     // fetching untouched records still works, however the middle record batch is NOT half-deleted and still contains
     // record_2. `fetch_records` should filter this however.
-    let (records, _watermark) = partition_client
+    let FetchResult {
+        records,
+        high_watermark: _,
+        ..
+    } = partition_client
         .fetch_records(offset_3, 1..10_000, 1_000)
         .await
         .unwrap();

--- a/tests/produce_consume.rs
+++ b/tests/produce_consume.rs
@@ -439,7 +439,7 @@ async fn consume_rskafka(
             .fetch_records(offset, 0..1_000_000, 1_000)
             .await
             .unwrap()
-            .0;
+            .records;
         assert!(!res.is_empty());
         for record in res {
             offset = offset.max(record.offset);


### PR DESCRIPTION
Closes #

Return encoded Kafka response sizes to callers.

`Messenger` records the response frame size before decoding it. `PartitionClient::fetch_records` returns a `FetchResult` containing records, high watermark, and encoded response size. `StreamConsumer` and client tests use the structured result.

This changes the public return type of `PartitionClient::fetch_records` from a tuple to `FetchResult`.

- [ ] I've read the contributing section of the project [CONTRIBUTING.md](https://github.com/influxdata/rskafka/blob/main/CONTRIBUTING.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
